### PR TITLE
Illustrates how trait objects can be used

### DIFF
--- a/event_driven/tests/exercise_fsm.rs
+++ b/event_driven/tests/exercise_fsm.rs
@@ -1,5 +1,7 @@
 // Declare our state, commands and events
 
+use std::marker::PhantomData;
+
 use edfsm::{impl_fsm, Fsm};
 
 struct A;
@@ -29,12 +31,24 @@ enum Output {
     O2(O2),
 }
 
+// This next bit of code illustrates how a trait can be used to declare
+// effect handlers. We leverage Dynamically Sized Types to do this.
+// For more information: https://doc.rust-lang.org/nomicon/exotic-sizes.html#:~:text=Rust%20supports%20Dynamically%20Sized%20Types,DSTs%20are%20not%20normal%20types.
+
+trait EffectHandlers {
+    fn say_hi(&self);
+}
+
+struct EffectHandlerBox<SE: EffectHandlers + ?Sized>(SE);
+
 // Declare the FSM itself
 
-struct MyFsm {}
+struct MyFsm<SE: EffectHandlers> {
+    pub phantom: PhantomData<SE>,
+}
 
 #[impl_fsm]
-impl Fsm<State, Input, Output, ()> for MyFsm {
+impl<SE: EffectHandlers> Fsm<State, Input, Output, EffectHandlerBox<SE>> for MyFsm<SE> {
     state!(B / entry);
     state!(B / exit);
 
@@ -48,8 +62,9 @@ impl Fsm<State, Input, Output, ()> for MyFsm {
     transition!(_ => I3);
 }
 
-impl MyFsm {
-    fn for_a_i0_o0(_s: &A, _c: I0, _se: &mut ()) -> Option<O0> {
+impl<SE: EffectHandlers> MyFsm<SE> {
+    fn for_a_i0_o0(_s: &A, _c: I0, se: &mut EffectHandlerBox<SE>) -> Option<O0> {
+        se.0.say_hi();
         Some(O0)
     }
 
@@ -57,7 +72,7 @@ impl MyFsm {
         Some(B)
     }
 
-    fn for_b_i1_o1(_s: &B, _c: I1, _se: &mut ()) -> Option<O1> {
+    fn for_b_i1_o1(_s: &B, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
         Some(O1)
     }
 
@@ -65,13 +80,13 @@ impl MyFsm {
         Some(A)
     }
 
-    fn for_b_i2_o2(_s: &B, _c: I2, _se: &mut ()) -> Option<O2> {
+    fn for_b_i2_o2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
         Some(O2)
     }
 
-    fn for_b_i3(_s: &B, _c: I3, _se: &mut ()) {}
+    fn for_b_i3(_s: &B, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 
-    fn for_any_i1_o1(_s: &State, _c: I1, _se: &mut ()) -> Option<O1> {
+    fn for_any_i1_o1(_s: &State, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
         Some(O1)
     }
 
@@ -79,21 +94,29 @@ impl MyFsm {
         Some(A)
     }
 
-    fn for_any_i2_o2(_s: &State, _c: I2, _se: &mut ()) -> Option<O2> {
+    fn for_any_i2_o2(_s: &State, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
         Some(O2)
     }
 
-    fn for_any_i3(_s: &State, _c: I3, _se: &mut ()) {}
+    fn for_any_i3(_s: &State, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 
-    fn on_entry_b(_to_s: &B, _se: &mut ()) {}
+    fn on_entry_b(_to_s: &B, _se: &mut EffectHandlerBox<SE>) {}
 
-    fn on_exit_b(_old_s: &B, _se: &mut ()) {}
+    fn on_exit_b(_old_s: &B, _se: &mut EffectHandlerBox<SE>) {}
 }
 
 #[test]
 fn main() {
-    let _ = MyFsm::step(&State::A(A), Input::I0(I0), &mut ());
-    let _ = MyFsm::step(&State::B(B), Input::I1(I1), &mut ());
-    let _ = MyFsm::step(&State::B(B), Input::I2(I2), &mut ());
-    let _ = MyFsm::step(&State::B(B), Input::I3(I3), &mut ());
+    struct MyEffectHandlers;
+    impl EffectHandlers for MyEffectHandlers {
+        fn say_hi(&self) {
+            println!("hi!");
+        }
+    }
+    let mut se = EffectHandlerBox(MyEffectHandlers);
+
+    let _ = MyFsm::step(&State::A(A), Input::I0(I0), &mut se);
+    let _ = MyFsm::step(&State::B(B), Input::I1(I1), &mut se);
+    let _ = MyFsm::step(&State::B(B), Input::I2(I2), &mut se);
+    let _ = MyFsm::step(&State::B(B), Input::I3(I3), &mut se);
 }


### PR DESCRIPTION
We illustrate how trait objects can be used via [dynamically sized types](https://doc.rust-lang.org/nomicon/exotic-sizes.html#:~:text=Rust%20supports%20Dynamically%20Sized%20Types,DSTs%20are%20not%20normal%20types). This then permits multiple trait implementations to be used as effect handlers.