### PR TITLE
Simplify method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ The `transition!` macro declares an entire transition using the form:
 In our example, for the first transition, multiple methods will be called that the developer must provide e.g.:
 
 ```rust
-fn for_idle_start_started(_s: &Idle, _c: Start, _se: &mut EffectHandlers) -> Option<Started> {
+fn for_idle_start(_s: &Idle, _c: Start, _se: &mut EffectHandlers) -> Option<Started> {
     // Perform some effect here if required. Effects are performed via the EffectHandler
     Some(Started)
 }
 
-fn for_idle_started_running(_s: &Idle, _e: &Started) -> Option<Running> {
+fn on_idle_started(_s: &Idle, _e: &Started) -> Option<Running> {
     Some(Running)
 }
 ```

--- a/event_driven/tests/exercise_fsm.rs
+++ b/event_driven/tests/exercise_fsm.rs
@@ -63,46 +63,46 @@ impl<SE: EffectHandlers> Fsm<State, Input, Output, EffectHandlerBox<SE>> for MyF
 }
 
 impl<SE: EffectHandlers> MyFsm<SE> {
-    fn for_a_i0_o0(_s: &A, _c: I0, se: &mut EffectHandlerBox<SE>) -> Option<O0> {
+    fn for_a_i0(_s: &A, _c: I0, se: &mut EffectHandlerBox<SE>) -> Option<O0> {
         se.0.say_hi();
         Some(O0)
     }
 
-    fn for_a_o0_b(_s: &A, _e: &O0) -> Option<B> {
+    fn on_a_o0(_s: &A, _e: &O0) -> Option<B> {
         Some(B)
     }
 
-    fn for_b_i1_o1(_s: &B, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
+    fn on_entry_b(_to_s: &B, _se: &mut EffectHandlerBox<SE>) {}
+
+    fn for_b_i1(_s: &B, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
         Some(O1)
     }
 
-    fn for_b_o1_a(_s: &B, _e: &O1) -> Option<A> {
+    fn on_b_o1(_s: &B, _e: &O1) -> Option<A> {
         Some(A)
     }
 
-    fn for_b_i2_o2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
+    fn for_b_i2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
         Some(O2)
     }
 
     fn for_b_i3(_s: &B, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 
-    fn for_any_i1_o1(_s: &State, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
+    fn on_exit_b(_old_s: &B, _se: &mut EffectHandlerBox<SE>) {}
+
+    fn for_any_i1(_s: &State, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
         Some(O1)
     }
 
-    fn for_any_o1_a(_s: &State, _e: &O1) -> Option<A> {
+    fn for_any_o1(_s: &State, _e: &O1) -> Option<A> {
         Some(A)
     }
 
-    fn for_any_i2_o2(_s: &State, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
+    fn for_any_i2(_s: &State, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
         Some(O2)
     }
 
     fn for_any_i3(_s: &State, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
-
-    fn on_entry_b(_to_s: &B, _se: &mut EffectHandlerBox<SE>) {}
-
-    fn on_exit_b(_old_s: &B, _se: &mut EffectHandlerBox<SE>) {}
 }
 
 #[test]

--- a/event_driven/tests/simple_valid_imp_fsm.rs
+++ b/event_driven/tests/simple_valid_imp_fsm.rs
@@ -64,34 +64,30 @@ impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
 }
 
 impl MyFsm {
-    fn for_running_stop_stopped(
-        _s: &Running,
-        _c: Stop,
-        se: &mut EffectHandlers,
-    ) -> Option<Stopped> {
+    fn on_entry_running(_to_s: &Running, se: &mut EffectHandlers) {
+        se.to_running()
+    }
+
+    fn for_running_stop(_s: &Running, _c: Stop, se: &mut EffectHandlers) -> Option<Stopped> {
         se.stop_something();
         Some(Stopped)
-    }
-
-    fn for_idle_start_started(_s: &Idle, _c: Start, se: &mut EffectHandlers) -> Option<Started> {
-        se.start_something();
-        Some(Started)
-    }
-
-    fn for_running_stopped_idle(_s: &Running, _e: &Stopped) -> Option<Idle> {
-        Some(Idle)
-    }
-
-    fn for_idle_started_running(_s: &Idle, _e: &Started) -> Option<Running> {
-        Some(Running)
     }
 
     fn on_exit_running(_old_s: &Running, se: &mut EffectHandlers) {
         se.from_running()
     }
 
-    fn on_entry_running(_to_s: &Running, se: &mut EffectHandlers) {
-        se.to_running()
+    fn on_running_stopped(_s: &Running, _e: &Stopped) -> Option<Idle> {
+        Some(Idle)
+    }
+
+    fn for_idle_start(_s: &Idle, _c: Start, se: &mut EffectHandlers) -> Option<Started> {
+        se.start_something();
+        Some(Started)
+    }
+
+    fn on_idle_started(_s: &Idle, _e: &Started) -> Option<Running> {
+        Some(Running)
     }
 }
 

--- a/event_driven_macros/src/parse.rs
+++ b/event_driven_macros/src/parse.rs
@@ -6,7 +6,7 @@ use syn::{
     parse2, Error, Ident, ImplItem, ImplItemMacro, ItemImpl, Result, Token, Type,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct EntryExit {
     pub is_entry: bool,
     pub state: Type,
@@ -29,7 +29,7 @@ impl Parse for EntryExit {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Transition {
     pub from_state: Type,
     pub command: Type,


### PR DESCRIPTION
The changes help distinguish between command and event handler methods by using the "for" and "on" prefixes respectively. Furthermore, the return type is removed from the method signature as it is not needed given that the compiler will check that the correct type is returned.

A small internal benefit is that the code size of the macro is reduced slightly given the commonality of method names without consideration of their return type.