### PR TITLE
Permits the conveying of multiple states given an event change

### DIFF
--- a/event_driven/tests/exercise_fsm.rs
+++ b/event_driven/tests/exercise_fsm.rs
@@ -53,7 +53,7 @@ impl<SE: EffectHandlers> Fsm<State, Input, Output, EffectHandlerBox<SE>> for MyF
     state!(B / exit);
 
     transition!(A => I0 => O0 => B);
-    transition!(B => I1 => O1 => A);
+    transition!(B => I1 => O1 => A | B);
     transition!(B => I2 => O2);
     transition!(B => I3);
 
@@ -78,8 +78,8 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(O1)
     }
 
-    fn on_b_o1(_s: &B, _e: &O1) -> Option<A> {
-        Some(A)
+    fn on_b_o1(_s: &B, _e: &O1) -> Option<State> {
+        Some(State::A(A))
     }
 
     fn for_b_i2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {

--- a/event_driven_macros/src/expand.rs
+++ b/event_driven_macros/src/expand.rs
@@ -91,10 +91,14 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
         } else {
             None
         };
-        let to_state = if let Some(to_state) = &t.to_state {
-            Some(ident_from_type(to_state)?)
+        let (to_state, to_state_explicit) = if let Some(to_state) = &t.to_state {
+            match to_state.states.as_slice() {
+                [single_type] => (Some(ident_from_type(single_type)?), true),
+                [first_type, ..] => (Some(ident_from_type(first_type)?), false),
+                _ => panic!("There must be at least one element"),
+            }
         } else {
-            None
+            (None, false)
         };
 
         if let Some(from_state) = from_state {
@@ -136,20 +140,36 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
                 if let Some(event) = event {
                     let event_handler =
                         lowercase_ident(&format_ident!("on_{}_{}", from_state, event));
-                    event_matches.push(quote!(
-                        (#state_enum::#from_state(s), #event_enum::#event(e)) => {
-                            Self::#event_handler(s, e).map(|r| #state_enum::#to_state(r))
-                        }
-                    ));
+                    if to_state_explicit {
+                        event_matches.push(quote!(
+                            (#state_enum::#from_state(s), #event_enum::#event(e)) => {
+                                Self::#event_handler(s, e).map(|r| #state_enum::#to_state(r))
+                            }
+                        ));
+                    } else {
+                        event_matches.push(quote!(
+                            (#state_enum::#from_state(s), #event_enum::#event(e)) => {
+                                Self::#event_handler(s, e)
+                            }
+                        ));
+                    }
                 }
             } else {
                 let event = event.unwrap(); // Logic error if no event given a to_state.
                 let event_handler = lowercase_ident(&format_ident!("on_any_{}", event));
-                event_matches.push(quote!(
-                    (_, #event_enum::#event(e)) => {
-                        Self::#event_handler(s, e).map(|r| #state_enum::#to_state(r))
-                    }
-                ));
+                if to_state_explicit {
+                    event_matches.push(quote!(
+                        (_, #event_enum::#event(e)) => {
+                            Self::#event_handler(s, e).map(|r| #state_enum::#to_state(r))
+                        }
+                    ));
+                } else {
+                    event_matches.push(quote!(
+                        (_, #event_enum::#event(e)) => {
+                            Self::#event_handler(s, e)
+                        }
+                    ));
+                }
             };
         }
     }


### PR DESCRIPTION
During the crafting of a new FSM in my app, I noticed that we hadn't catered for supporting the scenario where a state transition given an event could yield multiple states. This scenario also manifests itself in another app where we aren't using the macro here.

To achieve this, I introduce a means of expressing the multitude of types that an event transition can produce. While I could have used the more conventional inferred type ("_"), I feel it is important to retain the documentation here. One of the goals of this project is to have the macros convey a diagram as closely as it can. An inferred type would prevent a diagram from being generated. Instead, I introduce a "|" syntax.

Here's an example of the multiple states expression taken from one of the tests:

```rust
impl Fsm<State, Command, Event, EffectHandlers> for SomeFsm {
    transition!(S0  => C => E => S0 | S1);
}
```

In this example, either S0 or S1 should be returned - although this can't be enforced as we don't have anon enum types in Rust. However, the syntax I've chosen is also the same as declaring union types you have in Typescript and Scala, which would be reasonable for Rust to adopt at some point (there's been plenty of discussion on it, although not much action).

The error reporting is nice. If anything other than a State type is returned from the event handler then the compiler tells you. Similarly, if you provide a single type then the compiler (via the macro) will ensure that it is an enum variant (this was there before).