### PR TITLE
Entry/exit called only if the transitioning states are different

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ fn on_exit_running(_old_s: &Running, _se: &mut EffectHandlers) {
 The `transition!` macro declares an entire transition using the form:
 
 ```
-<from-state> => <given-command> => <yields-event> => <to-state>
+<from-state> => <given-command> [=> <yields-event> []=> <to-state>]]
 ```
 
 In our example, for the first transition, multiple methods will be called that the developer must provide e.g.:

--- a/event_driven/src/lib.rs
+++ b/event_driven/src/lib.rs
@@ -7,6 +7,8 @@
 
 #![no_std]
 
+use core::mem;
+
 pub use event_driven_macros::impl_fsm;
 
 /// Describes the behavior of a Finite State Machine (FSM) that can receive commands and produce
@@ -52,8 +54,10 @@ pub trait Fsm<S, C, E, SE> {
         let t = if let Some(e) = &e {
             let t = Self::on_event(s, e);
             if let Some(new_s) = &t {
-                Self::on_exit(s, se);
-                Self::on_entry(new_s, se);
+                if mem::discriminant(new_s) != mem::discriminant(s) {
+                    Self::on_exit(s, se);
+                    Self::on_entry(new_s, se);
+                }
             };
             t
         } else {

--- a/event_driven_macros/src/expand.rs
+++ b/event_driven_macros/src/expand.rs
@@ -218,6 +218,12 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
             }
         ))
         .unwrap(),
+        parse2::<ImplItem>(quote!(
+            fn is_transitioning(s0: &#state_enum, s1: &#state_enum) -> bool {
+                core::mem::discriminant(s0) != core::mem::discriminant(s1)
+            }
+        ))
+        .unwrap(),
     ];
     Ok(fsm.item_impl.to_token_stream())
 }

--- a/event_driven_macros/src/lib.rs
+++ b/event_driven_macros/src/lib.rs
@@ -5,6 +5,52 @@ mod parse;
 use proc_macro_error::{abort_call_site, proc_macro_error};
 use syn::parse2;
 
+/// Provides a DSL that conveniently implements the FSM trait.
+/// States, Commands and Events are all required to be implemented
+/// both as structs and enums.
+///
+/// An example:
+///
+/// ```compile_fail
+/// #[impl_fsm]
+/// impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
+///     state!(Running / entry);
+///     state!(Running / exit);
+///
+///     transition!(Idle    => Start => Started => Running);
+///     transition!(Running => Stop  => Stopped => Idle);
+/// }
+/// ```
+///
+/// The `state!` macro declares state-related attributes. At this time, entry and exit
+/// handlers can be declared. In our example, the macro will ensure that an `on_entry_running`
+/// and an `on_exit_running` method will be called for `MyFsm`. The developer is then
+/// required to implement these methods e.g.:
+///
+/// ```compile_fail
+/// fn on_exit_running(_old_s: &Running, _se: &mut EffectHandlers) {
+///     // Do something
+/// }
+/// ```
+///
+/// The `transition!` macro declares an entire transition using the form:
+///
+/// ```compile_fail
+/// <from-state> => <given-command> [=> <yields-event> []=> <to-state>]]
+/// ```
+///
+/// In our example, for the first transition, multiple methods will be called that the developer must provide e.g.:
+///
+/// ```compile_fail
+/// fn for_idle_start(_s: &Idle, _c: Start, _se: &mut EffectHandlers) -> Option<Started> {
+///     // Perform some effect here if required. Effects are performed via the EffectHandler
+///     Some(Started)
+/// }
+///
+/// fn on_idle_started(_s: &Idle, _e: &Started) -> Option<Running> {
+///     Some(Running)
+/// }
+/// ```
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn impl_fsm(input: TokenStream, annotated_item: TokenStream) -> TokenStream {


### PR DESCRIPTION
Prior to this PR, entry/exit handlers were called even when transitioning to the same state. The change here is to discriminant, accepting that if the state S is not an enum then the behaviour is undefined (the macros actually require S to be enum, so this should be fine).