### PR TITLE
Cater for both from and to states being anon

### DIFF
--- a/event_driven/tests/exercise_fsm.rs
+++ b/event_driven/tests/exercise_fsm.rs
@@ -102,6 +102,10 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(O2)
     }
 
+    fn on_any_o2(_s: &State, _e: &O2) -> Option<State> {
+        Some(State::A(A))
+    }
+
     fn for_any_i3(_s: &State, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 }
 

--- a/event_driven_macros/src/expand.rs
+++ b/event_driven_macros/src/expand.rs
@@ -171,6 +171,16 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
                     ));
                 }
             };
+        } else if from_state.is_none() {
+            // from and to states are None
+            if let Some(event) = event {
+                let event_handler = lowercase_ident(&format_ident!("on_any_{}", event));
+                event_matches.push(quote!(
+                    (_, #event_enum::#event(e)) => {
+                        Self::#event_handler(s, e)
+                    }
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
This is a bug fix for the case where both the from and to states are anon, and we have an event being emitted. We need to ensure that there's an event handler.

Previously, the following transition didn't require an event handler:

```
    transition!(_ => I2 => O2);
```

There's no point in having and event without an event handler.