### PR TITLE
Adds the ignore macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
 
     transition!(Idle    => Start => Started => Running);
     transition!(Running => Stop  => Stopped => Idle);
+
+    ignore!(Idle    => Stop);
+    ignore!(Running => Start);
 }
 ```
 
@@ -61,6 +64,14 @@ fn on_idle_started(_s: &Idle, _e: &Started) -> Option<Running> {
     Some(Running)
 }
 ```
+
+The `ignore!` macro describes those states and commands that should be ignored given:
+
+```
+<from-state> => <given-command>
+```
+
+It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 
 Please see the event_driven/tests folder for complete examples.
 

--- a/event_driven/tests/exercise_fsm.rs
+++ b/event_driven/tests/exercise_fsm.rs
@@ -60,6 +60,8 @@ impl<SE: EffectHandlers> Fsm<State, Input, Output, EffectHandlerBox<SE>> for MyF
     transition!(_ => I1 => O1 => A);
     transition!(_ => I2 => O2);
     transition!(_ => I3);
+
+    ignore!(B => I0);
 }
 
 impl<SE: EffectHandlers> MyFsm<SE> {

--- a/event_driven/tests/simple_valid_imp_fsm.rs
+++ b/event_driven/tests/simple_valid_imp_fsm.rs
@@ -61,6 +61,9 @@ impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
 
     transition!(Idle    => Start => Started => Running);
     transition!(Running => Stop  => Stopped => Idle);
+
+    ignore!(Idle    => Stop);
+    ignore!(Running => Start);
 }
 
 impl MyFsm {

--- a/event_driven_macros/src/lib.rs
+++ b/event_driven_macros/src/lib.rs
@@ -19,6 +19,9 @@ use syn::parse2;
 ///
 ///     transition!(Idle    => Start => Started => Running);
 ///     transition!(Running => Stop  => Stopped => Idle);
+///
+///     ignore!(Idle    => Stop);
+///     ignore!(Running => Start);
 /// }
 /// ```
 ///
@@ -51,6 +54,14 @@ use syn::parse2;
 ///     Some(Running)
 /// }
 /// ```
+///
+/// The `ignore!` macro describes those states and commands that should be ignored given:
+///
+/// ```compile_fail
+/// <from-state> => <given-command>
+/// ```
+///
+/// It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn impl_fsm(input: TokenStream, annotated_item: TokenStream) -> TokenStream {


### PR DESCRIPTION
The `ignore!` macro has been introduced to ensure that all state/command match arms are specified. This then forces the developer to consider state/command combinations to be ignored explicitly, and thereby avoid errors in their code.

An example:

```rust
#[impl_fsm]
impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
    state!(Running / entry);
    state!(Running / exit);

    transition!(Idle    => Start => Started => Running);
    transition!(Running => Stop  => Stopped => Idle);

    ignore!(Idle    => Stop);
    ignore!(Running => Start);
}
```

There are cases where it is possible to have duplicate match expressions i.e. state/command matching that appears in both the same `transition!` and `ignore!`. I think this is a limitation of the Rust compiler though. We could do more to detect these duplicates but I'm reluctant given the cost and complexity of running the macros and performing the checks. Also, a duplicate transition/ignore would be benign as transitions are always matched first.