### PR TITLE
Mutable state and associated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `ignore!` macro describes those states and commands that should be ignored g
 It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 
 State machines are then advanced given a mutable state and command. An optional event can be
-emitted, along with an indication of whether a state transition occurred e.g.:
+emitted along with a possible state transition e.g.:
 
 ```rust
 let mut s = State::Idle(Idle);
@@ -88,9 +88,8 @@ let c = Command::Start(Start);
 let (e, t) = MyFsm::step(&mut s, c, &mut se);
 ```
 
-State can also be re-constituted by replaying events. A bool indicates
-true if transition is returned. If there is no transition then the existing state
-may still have been updated.
+State can also be re-constituted by replaying events. If there is no transition to an entirely
+new state then the existing state may still have been updated.
 Here is an example of applying an event to state with the update of state
 if necessary and a bool of `t` indicating true if a transition occurred.
 
@@ -98,7 +97,7 @@ if necessary and a bool of `t` indicating true if a transition occurred.
 let t = MyFsm::on_event(&mut s, &e);
 ```
 
-Mutating state has been mentioned. This can be very useful where a state itself represents
+Mutating state can be very useful where a state itself represents
 a finer granularity of state with its fields, and so we wish to update them directly. 
 For example, given our previous representation of:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `ignore!` macro describes those states and commands that should be ignored g
 It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 
 State machines are then advanced given a mutable state and command. An optional event can be
-emitted, along with an optional state in the case of a transition e.g.:
+emitted, along with an indication of whether a state transition occurred e.g.:
 
 ```rust
 let mut s = State::Idle(Idle);
@@ -88,11 +88,11 @@ let c = Command::Start(Start);
 let (e, t) = MyFsm::step(&mut s, c, &mut se);
 ```
 
-State can also be re-constituted by replaying events. In this case, an
-optional transition is returned. If there is no transition then the state
-may still have been updated, noting that these two actions are mutually exclusive.
-Here is an example of applying an event to state with the return of an
-optional transition represented as a new state.
+State can also be re-constituted by replaying events. A bool indicates
+true if transition is returned. If there is no transition then the existing state
+may still have been updated.
+Here is an example of applying an event to state with the update of state
+if necessary and a bool of `t` indicating true if a transition occurred.
 
 ```rust
 let t = MyFsm::on_event(&mut s, &e);

--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ state, command and event types are handled by the developer.
 Here is an example given the declaration of states, commands, events and an effect handler:
 
 ```rust
-struct MyFsm {}
+struct MyFsm;
 
 #[impl_fsm]
-impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
+impl Fsm for MyFsm {
+    type S = State;
+    type C = Command;
+    type E = Event;
+    type SE = EffectHandlers;
+
     state!(Running / entry);
-    state!(Running / exit);
 
     transition!(Idle    => Start => Started => Running);
     transition!(Running => Stop  => Stopped => Idle);
@@ -35,13 +39,13 @@ impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
 }
 ```
 
-The `state!` macro declares state-related attributes. At this time, entry and exit
-handlers can be declared. In our example, the macro will ensure that an `on_entry_running`
-and an `on_exit_running` method will be called for `MyFsm`. The developer is then
+The `state!` macro declares state-related attributes. At this time, entry 
+handlers can be declared. In our example, the macro will ensure that a `on_entry_running`
+method will be called for `MyFsm`. The developer is then
 required to implement these methods e.g.:
 
 ```rust
-fn on_exit_running(_old_s: &Running, _se: &mut EffectHandlers) {
+fn on_entry_running(_old_s: &Running, _se: &mut EffectHandlers) {
     // Do something
 }
 ```
@@ -73,12 +77,59 @@ The `ignore!` macro describes those states and commands that should be ignored g
 
 It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 
-Please see the event_driven/tests folder for complete examples.
+State machines are then advanced given a mutable state and command. An optional event can be
+emitted, along with an optional state in the case of a transition e.g.:
+
+```rust
+let mut s = State::Idle(Idle);
+let c = Command::Start(Start);
+// Now step the state machine with the state and command,
+// and, an (undeclared) effect handler.
+let (e, t) = MyFsm::step(&mut s, c, &mut se);
+```
+
+State can also be re-constituted by replaying events. In this case, an
+optional transition is returned. If there is no transition then the state
+may still have been updated, noting that these two actions are mutually exclusive.
+Here is an example of applying an event to state with the return of an
+optional transition represented as a new state.
+
+```rust
+let t = MyFsm::on_event(&mut s, &e);
+```
+
+Mutating state has been mentioned. This can be very useful where a state itself represents
+a finer granularity of state with its fields, and so we wish to update them directly. 
+For example, given our previous representation of:
+
+```rust
+transition!(Running => Stop  => Stopped => Idle);
+```
+
+...if we change it to:
+
+```rust
+transition!(Running => Stop  => Stopped);
+```
+
+i.e. if we remove the target state, then the associated function will be able to mutate the
+state and no transition can be returned as they are mutually exclusive actions. Here is
+a sample signature in accordance with the above `transition`.
+
+```rust
+fn on_idle_started(s: &mut Idle, e: &Started) {
+    // `s` can now be mutated given some `e`.
+}
+```
+
+Please see the event_driven/tests folder for complete examples, including the ability to mutate
+the passed state in the absence of a target state i.e. when emitting an event but not
+transitioning.
 
 no_std
 ---
 
-The library is able to support`no_std`, particularly for usage on embedded targets.
+The library is able to support`no_std` and is designed for efficient usage with embedded targets.
 
 ## Contribution policy
 

--- a/event-driven-macros/src/expand.rs
+++ b/event-driven-macros/src/expand.rs
@@ -146,7 +146,7 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
             if let Some(event) = event {
                 let event_handler = lowercase_ident(&format_ident!("on_{}_{}", from_state, event));
                 event_matches.push(quote!(
-                    (#state_enum::#from_state(ref mut s), #event_enum::#event(e)) => {
+                    (#state_enum::#from_state(s), #event_enum::#event(e)) => {
                         Self::#event_handler(s, e);
                         None
                     }

--- a/event-driven-macros/src/expand.rs
+++ b/event-driven-macros/src/expand.rs
@@ -216,12 +216,18 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
         .unwrap(),
         parse2::<ImplItem>(quote!(
             fn on_event(
-                s: &mut #state_enum,
+                mut s: &mut #state_enum,
                 e: &#event_enum,
-            ) -> Option<#state_enum> {
-                match (s, e) {
+            ) -> bool {
+                let new_s = match (&mut s, e) {
                     #( #event_matches )*
                     _ => None,
+                };
+                if let Some(new_s) = new_s {
+                    *s = new_s;
+                    true
+                } else {
+                    false
                 }
             }
         ))

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -23,48 +23,40 @@ pub use event_driven_macros::impl_fsm;
 /// and then causing a state transition in relation to that result. While this approach adds
 /// steps to a state machine, it does allow them to remain responsive to receiving more
 /// commands.
-///
-/// The generic types refer to:
-/// S  = State          - the state of your FSM
-/// C  = Command        - the command(s) that are able to be processed on your FSM
-/// E  = Event          - the event(s) that are emitted having performed a command
-/// SE = State Effect   - the effect handler
-pub trait Fsm<S, C, E, SE> {
+pub trait Fsm: Sized {
+    /// The state managed by the FSM
+    type S;
+    /// The command(s) that are able to be processed by the FSM
+    type C;
+    /// The event emitted having performed a command
+    type E;
+    /// The side effect handler
+    type SE;
+
     /// Given a state and command, optionally emit an event. Can perform side
     /// effects along the way. This function is generally only called from the
     /// `run` function.
-    fn for_command(s: &S, c: C, se: &mut SE) -> Option<E>;
+    fn for_command(s: &Self::S, c: Self::C, se: &mut Self::SE) -> Option<Self::E>;
 
-    /// Given a state and event, produce a transition, which could transition to
+    /// Given a state and event, modify state, which could indicate transition to
     /// the next state. No side effects are to be performed. Can be used to replay
     /// events to attain a new state i.e. the major function of event sourcing.
-    fn on_event(s: &S, e: &E) -> Option<S>;
-
-    /// Optional effect on exiting a state i.e. transitioning out of state `S` into
-    /// another.
-    fn on_exit(_s: &S, _se: &mut SE) {}
+    fn on_event(s: &mut Self::S, e: &Self::E) -> Option<Self::S>;
 
     /// Optional effect on entering a state i.e. transitioning in to state `S` from
     /// another.
-    fn on_entry(_s: &S, _se: &mut SE) {}
-
-    /// Determines whether an actual state transition is to occur given two states, 'S'.
-    fn is_transitioning(s0: &S, s1: &S) -> bool;
+    fn on_entry(_s: &Self::S, _se: &mut Self::SE) {}
 
     /// This is the main entry point to the event driven FSM.
     /// Runs the state machine for a command, optionally performing effects,
-    /// producing an event and transitioning to a new state. Also
-    /// applies any "Entry/" or "Exit/" processing when arriving
-    /// at a new state.
-    fn step(s: &S, c: C, se: &mut SE) -> (Option<E>, Option<S>) {
+    /// producing an event and possibly transitioning to a new state. Also
+    /// applies any "Entry/" processing when arriving at a new state.
+    fn step(s: &mut Self::S, c: Self::C, se: &mut Self::SE) -> (Option<Self::E>, Option<Self::S>) {
         let e = Self::for_command(s, c, se);
         let t = if let Some(e) = &e {
             let t = Self::on_event(s, e);
             if let Some(new_s) = &t {
-                if Self::is_transitioning(s, new_s) {
-                    Self::on_exit(s, se);
-                    Self::on_entry(new_s, se);
-                }
+                Self::on_entry(new_s, se);
             };
             t
         } else {
@@ -109,7 +101,6 @@ mod tests {
             started: u32,
             stopped: u32,
             transitioned_stopped_to_started: u32,
-            transitioned_started_to_stopped: u32,
         }
 
         impl EffectHandlers {
@@ -121,10 +112,6 @@ mod tests {
                 self.stopped += 1;
             }
 
-            pub fn exit_running(&mut self) {
-                self.transitioned_started_to_stopped += 1;
-            }
-
             pub fn enter_running(&mut self) {
                 self.transitioned_stopped_to_started += 1;
             }
@@ -132,9 +119,14 @@ mod tests {
 
         // Declare the FSM itself
 
-        struct MyFsm {}
+        struct MyFsm;
 
-        impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
+        impl Fsm for MyFsm {
+            type S = State;
+            type C = Command;
+            type E = Event;
+            type SE = EffectHandlers;
+
             fn for_command(s: &State, c: Command, se: &mut EffectHandlers) -> Option<Event> {
                 match (s, c) {
                     (State::Running(s), Command::Stop(c)) => {
@@ -147,7 +139,7 @@ mod tests {
                 }
             }
 
-            fn on_event(s: &State, e: &Event) -> Option<State> {
+            fn on_event(s: &mut State, e: &Event) -> Option<State> {
                 match (s, e) {
                     (State::Running(s), Event::Stopped(e)) => {
                         Self::on_running_stopped(s, e).map(State::Idle)
@@ -167,23 +159,6 @@ mod tests {
                     Self::on_entry_running(s, se)
                 }
             }
-
-            // Let's implement this optional function to show how entry/exit
-            // processing can be achieved, and also confirm that our FSM is
-            // calling it.
-            fn on_exit(old_s: &State, se: &mut EffectHandlers) {
-                if let State::Running(s) = old_s {
-                    Self::on_exit_running(s, se)
-                }
-            }
-
-            // [mem::discriminant] is used to compare an old state's and a new state's
-            // variants given that `State` represents an enum.
-            // [mem::discriminant]'s use where `State` is not an enum is undefined, which would
-            // therefore warrant a different implementation of this function.
-            fn is_transitioning(s0: &State, s1: &State) -> bool {
-                core::mem::discriminant(s0) != core::mem::discriminant(s1)
-            }
         }
 
         impl MyFsm {
@@ -198,10 +173,6 @@ mod tests {
             ) -> Option<Stopped> {
                 se.stop_something();
                 Some(Stopped)
-            }
-
-            fn on_exit_running(_old_s: &Running, se: &mut EffectHandlers) {
-                se.exit_running()
             }
 
             fn on_running_stopped(_s: &Running, _e: &Stopped) -> Option<Idle> {
@@ -224,41 +195,36 @@ mod tests {
             started: 0,
             stopped: 0,
             transitioned_stopped_to_started: 0,
-            transitioned_started_to_stopped: 0,
         };
 
         // Finally, test the FSM by stepping through various states
 
-        let (e, t) = MyFsm::step(&State::Idle(Idle), Command::Start(Start), &mut se);
+        let (e, t) = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
         assert!(matches!(e, Some(Event::Started(Started))));
         assert!(matches!(t, Some(State::Running(Running))));
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 0);
-        assert_eq!(se.transitioned_started_to_stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let (e, t) = MyFsm::step(&State::Running(Running), Command::Start(Start), &mut se);
+        let (e, t) = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
         assert!(e.is_none());
         assert!(t.is_none());
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 0);
-        assert_eq!(se.transitioned_started_to_stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let (e, t) = MyFsm::step(&State::Running(Running), Command::Stop(Stop), &mut se);
+        let (e, t) = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
         assert!(matches!(e, Some(Event::Stopped(Stopped))));
         assert!(matches!(t, Some(State::Idle(Idle))));
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 1);
-        assert_eq!(se.transitioned_started_to_stopped, 1);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let (e, t) = MyFsm::step(&State::Idle(Idle), Command::Stop(Stop), &mut se);
+        let (e, t) = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
         assert!(e.is_none());
         assert!(t.is_none());
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 1);
-        assert_eq!(se.transitioned_started_to_stopped, 1);
         assert_eq!(se.transitioned_stopped_to_started, 1);
     }
 }

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -23,7 +23,7 @@ pub use event_driven_macros::impl_fsm;
 /// and then causing a state transition in relation to that result. While this approach adds
 /// steps to a state machine, it does allow them to remain responsive to receiving more
 /// commands.
-pub trait Fsm: Sized {
+pub trait Fsm {
     /// The state managed by the FSM
     type S;
     /// The command(s) that are able to be processed by the FSM

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -48,9 +48,13 @@ struct MyFsm<SE: EffectHandlers> {
 }
 
 #[impl_fsm]
-impl<SE: EffectHandlers> Fsm<State, Input, Output, EffectHandlerBox<SE>> for MyFsm<SE> {
+impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
+    type S = State;
+    type C = Input;
+    type E = Output;
+    type SE = EffectHandlerBox<SE>;
+
     state!(B / entry);
-    state!(B / exit);
 
     transition!(A => I0 => O0 => B);
     transition!(B => I1 => O1 => A | B);
@@ -88,9 +92,9 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(O2)
     }
 
-    fn for_b_i3(_s: &B, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
+    fn on_b_o2(_s: &B, _e: &O2) {}
 
-    fn on_exit_b(_old_s: &B, _se: &mut EffectHandlerBox<SE>) {}
+    fn for_b_i3(_s: &B, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 
     fn for_any_i1(_s: &State, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
         Some(O1)
@@ -104,9 +108,7 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(O2)
     }
 
-    fn on_any_o2(_s: &State, _e: &O2) -> Option<State> {
-        Some(State::A(A))
-    }
+    fn on_any_o2(_s: &mut State, _e: &O2) {}
 
     fn for_any_i3(_s: &State, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 }
@@ -121,8 +123,8 @@ fn main() {
     }
     let mut se = EffectHandlerBox(MyEffectHandlers);
 
-    let _ = MyFsm::step(&State::A(A), Input::I0(I0), &mut se);
-    let _ = MyFsm::step(&State::B(B), Input::I1(I1), &mut se);
-    let _ = MyFsm::step(&State::B(B), Input::I2(I2), &mut se);
-    let _ = MyFsm::step(&State::B(B), Input::I3(I3), &mut se);
+    let _ = MyFsm::step(&mut State::A(A), Input::I0(I0), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::I1(I1), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::I2(I2), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::I3(I3), &mut se);
 }

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -103,28 +103,28 @@ fn main() {
 
     let (e, t) = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
     assert!(matches!(e, Some(Event::Started(Started))));
-    assert!(matches!(t, Some(State::Running(Running))));
+    assert!(t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
     let (e, t) = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
     assert!(e.is_none());
-    assert!(t.is_none());
+    assert!(!t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
     let (e, t) = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
     assert!(matches!(e, Some(Event::Stopped(Stopped))));
-    assert!(matches!(t, Some(State::Idle(Idle))));
+    assert!(t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
     let (e, t) = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
     assert!(e.is_none());
-    assert!(t.is_none());
+    assert!(!t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -101,30 +101,26 @@ fn main() {
 
     // Finally, test the FSM by stepping through various states
 
-    let (e, t) = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
+    let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
     assert!(matches!(e, Some(Event::Started(Started))));
-    assert!(t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let (e, t) = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
+    let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
     assert!(e.is_none());
-    assert!(!t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let (e, t) = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
     assert!(matches!(e, Some(Event::Stopped(Stopped))));
-    assert!(t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let (e, t) = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
     assert!(e.is_none());
-    assert!(!t);
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);


### PR DESCRIPTION
State is now passed in as being mutable so that some handlers may efficiently update state. A consequence of mutable state is that we can no longer have exit handlers, otherwise we would have to clone state so that we can pass it to an exit handler once event processing has occurred. On having analysed our own usage of edfsm, we felt that exit handlers can generally be replaced with entry handlers, which are retained. There is a tradeoff when it comes to having removed exit handlers. It can mean that more entry handlers are required, but we feel that being able to mutate state in some circumstances presents a much larger benefit.

Mutating state also permits us to clearly identify a transition vs an update to state. Consequently, the `is_transitioning` function is no longer required. This simplifies our code base further.

Associated types are now used in place of generics. One reason for this is so that a state machine can be confined to representing just one FSM. Associated types also make it easier to pass FSMs around and compose them with other structures as they are self-contained.

Finally, the `step` function has been simplified by only returning an optional event. As state is mutated in place, there's no real need to signal that a transition has occurred. The event should be enough and is in terms of how we've been using it.