### PR TITLE
Allow side effects to be async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
+rust-version = "1.75.0"
 
 members = [
     "event-driven",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "event-driven",

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The library is able to support`no_std` and is designed for efficient usage with 
 Minimum supported Rust
 ---
 
-streambed-rs requires a minimum of Rust version 1.70.0 stable (June 2023), but the most recent stable version of Rust is recommended.
+This library requires a minimum of Rust version 1.75.0 stable (December 2023), but the most recent stable version of Rust is recommended.
 
 Contribution policy
 ---

--- a/README.md
+++ b/README.md
@@ -130,11 +130,19 @@ no_std
 
 The library is able to support`no_std` and is designed for efficient usage with embedded targets.
 
-## Contribution policy
+
+Minimum supported Rust
+---
+
+streambed-rs requires a minimum of Rust version 1.70.0 stable (June 2023), but the most recent stable version of Rust is recommended.
+
+Contribution policy
+---
 
 Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
 
-## License
+License
+---
 
 This code is open source software licensed under the [Apache-2.0 license](./LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ edfsm - Event Driven Finite State Machine
 ===
 
 Event driven Finite State Machines process commands (possibly created by other
-events), possibly performing some side effect, and possibly emitting events.
+events), possibly performing some async side effect, and possibly emitting events.
 
 Commands are processed against a provided state. Events can be applied to states
 to yield new states.
@@ -45,7 +45,7 @@ method will be called for `MyFsm`. The developer is then
 required to implement these methods e.g.:
 
 ```rust
-fn on_entry_running(_old_s: &Running, _se: &mut EffectHandlers) {
+async fn on_entry_running(_old_s: &Running, _se: &mut EffectHandlers) {
     // Do something
 }
 ```
@@ -59,7 +59,7 @@ The `transition!` macro declares an entire transition using the form:
 In our example, for the first transition, multiple methods will be called that the developer must provide e.g.:
 
 ```rust
-fn for_idle_start(_s: &Idle, _c: Start, _se: &mut EffectHandlers) -> Option<Started> {
+async fn for_idle_start(_s: &Idle, _c: Start, _se: &mut EffectHandlers) -> Option<Started> {
     // Perform some effect here if required. Effects are performed via the EffectHandler
     Some(Started)
 }
@@ -85,7 +85,7 @@ let mut s = State::Idle(Idle);
 let c = Command::Start(Start);
 // Now step the state machine with the state and command,
 // and, an (undeclared) effect handler.
-let (e, t) = MyFsm::step(&mut s, c, &mut se);
+let (e, t) = MyFsm::step(&mut s, c, &mut se).await;
 ```
 
 State can also be re-constituted by replaying events. If there is no transition to an entirely

--- a/event-driven-macros/src/expand.rs
+++ b/event-driven-macros/src/expand.rs
@@ -43,7 +43,7 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
         let handler = format_ident!("on_entry_{}", state);
         let handler = Ident::new(&handler.to_string().to_lowercase(), handler.span());
         entry_matches.push(quote!(
-            #state_enum::#state(s) => Self::#handler(s, se),
+            #state_enum::#state(s) => Self::#handler(s, se).await,
         ));
     }
 
@@ -77,13 +77,13 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
             if let Some(event) = event {
                 command_matches.push(quote!(
                     (#state_enum::#from_state(s), #command_enum::#command(c)) => {
-                        Self::#command_handler(s, c, se).map(#event_enum::#event)
+                        Self::#command_handler(s, c, se).await.map(#event_enum::#event)
                     }
                 ));
             } else {
                 command_matches.push(quote!(
                     (#state_enum::#from_state(s), #command_enum::#command(c)) => {
-                        Self::#command_handler(s, c, se);
+                        Self::#command_handler(s, c, se).await;
                         None
                     }
                 ));
@@ -93,13 +93,13 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
             if let Some(event) = event {
                 command_matches.push(quote!(
                     (_, #command_enum::#command(c)) => {
-                        Self::#command_handler(s, c, se).map(#event_enum::#event)
+                        Self::#command_handler(s, c, se).await.map(#event_enum::#event)
                     }
                 ));
             } else {
                 command_matches.push(quote!(
                     (_, #command_enum::#command(c)) => {
-                        Self::#command_handler(s, c, se);
+                        Self::#command_handler(s, c, se).await;
                         None
                     }
                 ));
@@ -203,7 +203,7 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
         ))
         .unwrap(),
         parse2::<ImplItem>(quote!(
-            fn for_command(
+            async fn for_command(
                 s: &#state_enum,
                 c: #command_enum,
                 se: &mut #effect_handlers,
@@ -233,7 +233,7 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
         ))
         .unwrap(),
         parse2::<ImplItem>(quote!(
-            fn on_entry(new_s: &#state_enum, se: &mut #effect_handlers) {
+            async fn on_entry(new_s: &#state_enum, se: &mut #effect_handlers) {
                 match new_s {
                     #( #entry_matches )*
                     _ => {}

--- a/event-driven-macros/src/lib.rs
+++ b/event-driven-macros/src/lib.rs
@@ -15,7 +15,6 @@ use syn::parse2;
 /// #[impl_fsm]
 /// impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
 ///     state!(Running / entry);
-///     state!(Running / exit);
 ///
 ///     transition!(Idle    => Start => Started => Running);
 ///     transition!(Running => Stop  => Stopped => Idle);
@@ -31,7 +30,7 @@ use syn::parse2;
 /// required to implement these methods e.g.:
 ///
 /// ```compile_fail
-/// fn on_exit_running(_old_s: &Running, _se: &mut EffectHandlers) {
+/// async fn on_entry_running(_old_s: &Running, _se: &mut EffectHandlers) {
 ///     // Do something
 /// }
 /// ```
@@ -45,7 +44,7 @@ use syn::parse2;
 /// In our example, for the first transition, multiple methods will be called that the developer must provide e.g.:
 ///
 /// ```compile_fail
-/// fn for_idle_start(_s: &Idle, _c: Start, _se: &mut EffectHandlers) -> Option<Started> {
+/// async fn for_idle_start(_s: &Idle, _c: Start, _se: &mut EffectHandlers) -> Option<Started> {
 ///     // Perform some effect here if required. Effects are performed via the EffectHandler
 ///     Some(Started)
 /// }

--- a/event-driven/Cargo.toml
+++ b/event-driven/Cargo.toml
@@ -9,3 +9,7 @@ repository = "https://github.com/titanclass/edfsm.git"
 
 [dependencies]
 event-driven-macros = { path = "../event-driven-macros", version = "0.6.0" }
+
+[dev-dependencies]
+test-log = "0.2.11"
+tokio = {version = "1.23.0", features = ["rt-multi-thread", "macros"] }

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -27,13 +27,13 @@ pub use event_driven_macros::impl_fsm;
 /// commands.
 pub trait Fsm {
     /// The state managed by the FSM
-    type S: Send;
+    type S;
     /// The command(s) that are able to be processed by the FSM
-    type C: Send;
+    type C;
     /// The event emitted having performed a command
-    type E: Send;
+    type E;
     /// The side effect handler
-    type SE: Send;
+    type SE;
 
     /// Given a state and command, optionally emit an event. Can perform async side
     /// effects along the way. This function is generally only called from the
@@ -42,7 +42,7 @@ pub trait Fsm {
         s: &Self::S,
         c: Self::C,
         se: &mut Self::SE,
-    ) -> impl Future<Output = Option<Self::E>> + Send;
+    ) -> impl Future<Output = Option<Self::E>>;
 
     /// Given a state and event, modify state, which could indicate transition to
     /// the next state. No side effects are to be performed. Can be used to replay
@@ -51,7 +51,7 @@ pub trait Fsm {
 
     /// Optional effect on entering a state i.e. transitioning in to state `S` from
     /// another.
-    fn on_entry(_s: &Self::S, _se: &mut Self::SE) -> impl Future<Output = ()> + Send;
+    fn on_entry(_s: &Self::S, _se: &mut Self::SE) -> impl Future<Output = ()>;
 
     /// This is the main entry point to the event driven FSM.
     /// Runs the state machine for a command, optionally performing effects,
@@ -61,7 +61,7 @@ pub trait Fsm {
         s: &mut Self::S,
         c: Self::C,
         se: &mut Self::SE,
-    ) -> impl Future<Output = Option<Self::E>> + Send {
+    ) -> impl Future<Output = Option<Self::E>> {
         async {
             let e = Self::for_command(s, c, se).await;
             if let Some(e) = &e {

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -7,6 +7,8 @@
 
 #![no_std]
 
+use core::future::Future;
+
 pub use event_driven_macros::impl_fsm;
 
 /// Describes the behavior of a Finite State Machine (FSM) that can receive commands and produce
@@ -25,18 +27,22 @@ pub use event_driven_macros::impl_fsm;
 /// commands.
 pub trait Fsm {
     /// The state managed by the FSM
-    type S;
+    type S: Send;
     /// The command(s) that are able to be processed by the FSM
-    type C;
+    type C: Send;
     /// The event emitted having performed a command
-    type E;
+    type E: Send;
     /// The side effect handler
-    type SE;
+    type SE: Send;
 
-    /// Given a state and command, optionally emit an event. Can perform side
+    /// Given a state and command, optionally emit an event. Can perform async side
     /// effects along the way. This function is generally only called from the
     /// `run` function.
-    fn for_command(s: &Self::S, c: Self::C, se: &mut Self::SE) -> Option<Self::E>;
+    fn for_command(
+        s: &Self::S,
+        c: Self::C,
+        se: &mut Self::SE,
+    ) -> impl Future<Output = Option<Self::E>> + Send;
 
     /// Given a state and event, modify state, which could indicate transition to
     /// the next state. No side effects are to be performed. Can be used to replay
@@ -45,21 +51,27 @@ pub trait Fsm {
 
     /// Optional effect on entering a state i.e. transitioning in to state `S` from
     /// another.
-    fn on_entry(_s: &Self::S, _se: &mut Self::SE) {}
+    fn on_entry(_s: &Self::S, _se: &mut Self::SE) -> impl Future<Output = ()> + Send;
 
     /// This is the main entry point to the event driven FSM.
     /// Runs the state machine for a command, optionally performing effects,
     /// possibly producing an event and possibly transitioning to a new state. Also
     /// applies any "Entry/" processing when arriving at a new state.
-    fn step(s: &mut Self::S, c: Self::C, se: &mut Self::SE) -> Option<Self::E> {
-        let e = Self::for_command(s, c, se);
-        if let Some(e) = &e {
-            let t = Self::on_event(s, e);
-            if t {
-                Self::on_entry(s, se);
+    fn step(
+        s: &mut Self::S,
+        c: Self::C,
+        se: &mut Self::SE,
+    ) -> impl Future<Output = Option<Self::E>> + Send {
+        async {
+            let e = Self::for_command(s, c, se).await;
+            if let Some(e) = &e {
+                let t = Self::on_event(s, e);
+                if t {
+                    Self::on_entry(s, se).await;
+                };
             };
-        };
-        e
+            e
+        }
     }
 }
 
@@ -67,8 +79,10 @@ pub trait Fsm {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_step() {
+    use test_log::test;
+
+    #[test(tokio::test)]
+    async fn test_step() {
         // Declare our state, commands and events
 
         struct Idle;
@@ -124,7 +138,7 @@ mod tests {
             type E = Event;
             type SE = EffectHandlers;
 
-            fn for_command(s: &State, c: Command, se: &mut EffectHandlers) -> Option<Event> {
+            async fn for_command(s: &State, c: Command, se: &mut EffectHandlers) -> Option<Event> {
                 match (s, c) {
                     (State::Running(s), Command::Stop(c)) => {
                         Self::for_running_stop(s, c, se).map(Event::Stopped)
@@ -157,7 +171,7 @@ mod tests {
             // Let's implement this optional function to show how entry/exit
             // processing can be achieved, and also confirm that our FSM is
             // calling it.
-            fn on_entry(new_s: &State, se: &mut EffectHandlers) {
+            async fn on_entry(new_s: &State, se: &mut EffectHandlers) {
                 if let State::Running(s) = new_s {
                     Self::on_entry_running(s, se)
                 }
@@ -202,25 +216,25 @@ mod tests {
 
         // Finally, test the FSM by stepping through various states
 
-        let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
+        let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se).await;
         assert!(matches!(e, Some(Event::Started(Started))));
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
+        let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se).await;
         assert!(e.is_none());
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
+        let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se).await;
         assert!(matches!(e, Some(Event::Stopped(Stopped))));
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 1);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
+        let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se).await;
         assert!(e.is_none());
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 1);

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -1,6 +1,6 @@
 // Declare our state, commands and events
 
-use std::marker::PhantomData;
+use std::{future::Future, marker::PhantomData};
 
 use edfsm::{impl_fsm, Fsm};
 
@@ -36,7 +36,7 @@ enum Output {
 // For more information: https://doc.rust-lang.org/nomicon/exotic-sizes.html#:~:text=Rust%20supports%20Dynamically%20Sized%20Types,DSTs%20are%20not%20normal%20types.
 
 trait EffectHandlers {
-    fn say_hi(&self);
+    fn say_hi(&self) -> impl Future<Output = ()> + Send;
 }
 
 struct EffectHandlerBox<SE: EffectHandlers + ?Sized>(SE);
@@ -48,7 +48,7 @@ struct MyFsm<SE: EffectHandlers> {
 }
 
 #[impl_fsm]
-impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
+impl<SE: EffectHandlers + Send> Fsm for MyFsm<SE> {
     type S = State;
     type C = Input;
     type E = Output;
@@ -69,8 +69,8 @@ impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
 }
 
 impl<SE: EffectHandlers> MyFsm<SE> {
-    fn for_a_i0(_s: &A, _c: I0, se: &mut EffectHandlerBox<SE>) -> Option<O0> {
-        se.0.say_hi();
+    async fn for_a_i0(_s: &A, _c: I0, se: &mut EffectHandlerBox<SE>) -> Option<O0> {
+        se.0.say_hi().await;
         Some(O0)
     }
 
@@ -78,9 +78,9 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(B)
     }
 
-    fn on_entry_b(_to_s: &B, _se: &mut EffectHandlerBox<SE>) {}
+    async fn on_entry_b(_to_s: &B, _se: &mut EffectHandlerBox<SE>) {}
 
-    fn for_b_i1(_s: &B, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
+    async fn for_b_i1(_s: &B, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
         Some(O1)
     }
 
@@ -88,15 +88,15 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(State::A(A))
     }
 
-    fn for_b_i2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
+    async fn for_b_i2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
         Some(O2)
     }
 
     fn on_b_o2(_s: &B, _e: &O2) {}
 
-    fn for_b_i3(_s: &B, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
+    async fn for_b_i3(_s: &B, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 
-    fn for_any_i1(_s: &State, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
+    async fn for_any_i1(_s: &State, _c: I1, _se: &mut EffectHandlerBox<SE>) -> Option<O1> {
         Some(O1)
     }
 
@@ -104,27 +104,27 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(A)
     }
 
-    fn for_any_i2(_s: &State, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
+    async fn for_any_i2(_s: &State, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {
         Some(O2)
     }
 
     fn on_any_o2(_s: &mut State, _e: &O2) {}
 
-    fn for_any_i3(_s: &State, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
+    async fn for_any_i3(_s: &State, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 }
 
-#[test]
-fn main() {
+#[tokio::test]
+async fn main() {
     struct MyEffectHandlers;
     impl EffectHandlers for MyEffectHandlers {
-        fn say_hi(&self) {
+        async fn say_hi(&self) {
             println!("hi!");
         }
     }
     let mut se = EffectHandlerBox(MyEffectHandlers);
 
-    let _ = MyFsm::step(&mut State::A(A), Input::I0(I0), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::I1(I1), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::I2(I2), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::I3(I3), &mut se);
+    let _ = MyFsm::step(&mut State::A(A), Input::I0(I0), &mut se).await;
+    let _ = MyFsm::step(&mut State::B(B), Input::I1(I1), &mut se).await;
+    let _ = MyFsm::step(&mut State::B(B), Input::I2(I2), &mut se).await;
+    let _ = MyFsm::step(&mut State::B(B), Input::I3(I3), &mut se).await;
 }

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -36,7 +36,7 @@ enum Output {
 // For more information: https://doc.rust-lang.org/nomicon/exotic-sizes.html#:~:text=Rust%20supports%20Dynamically%20Sized%20Types,DSTs%20are%20not%20normal%20types.
 
 trait EffectHandlers {
-    fn say_hi(&self) -> impl Future<Output = ()> + Send;
+    fn say_hi(&self) -> impl Future<Output = ()>;
 }
 
 struct EffectHandlerBox<SE: EffectHandlers + ?Sized>(SE);
@@ -48,7 +48,7 @@ struct MyFsm<SE: EffectHandlers> {
 }
 
 #[impl_fsm]
-impl<SE: EffectHandlers + Send> Fsm for MyFsm<SE> {
+impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
     type S = State;
     type C = Input;
     type E = Output;

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -66,11 +66,11 @@ impl Fsm for MyFsm {
 }
 
 impl MyFsm {
-    fn on_entry_running(_to_s: &Running, se: &mut EffectHandlers) {
+    async fn on_entry_running(_to_s: &Running, se: &mut EffectHandlers) {
         se.enter_running()
     }
 
-    fn for_running_stop(_s: &Running, _c: Stop, se: &mut EffectHandlers) -> Option<Stopped> {
+    async fn for_running_stop(_s: &Running, _c: Stop, se: &mut EffectHandlers) -> Option<Stopped> {
         se.stop_something();
         Some(Stopped)
     }
@@ -79,7 +79,7 @@ impl MyFsm {
         Some(Idle)
     }
 
-    fn for_idle_start(_s: &Idle, _c: Start, se: &mut EffectHandlers) -> Option<Started> {
+    async fn for_idle_start(_s: &Idle, _c: Start, se: &mut EffectHandlers) -> Option<Started> {
         se.start_something();
         Some(Started)
     }
@@ -89,8 +89,8 @@ impl MyFsm {
     }
 }
 
-#[test]
-fn main() {
+#[tokio::test]
+async fn main() {
     // Initialize our effect handlers
 
     let mut se = EffectHandlers {
@@ -101,25 +101,25 @@ fn main() {
 
     // Finally, test the FSM by stepping through various states
 
-    let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
+    let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se).await;
     assert!(matches!(e, Some(Event::Started(Started))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
+    let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se).await;
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se).await;
     assert!(matches!(e, Some(Event::Stopped(Stopped))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se).await;
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);


### PR DESCRIPTION
I've often found that side effects of the FSM are required to be async. A scenario that has come up regularly has been to send some command on a channel from a side effect. Prior to the changes here, that send would have to be a "try send" and possibly fail if the channel buffer is full. With the async changes here, we can back-pressure the send until the buffer frees up.

By providing an async command handler, the application developer can choose whether a side effect is to be async or not. The overhead from being non-async to async should be negligible. In the case where sync behaviour is still required, the time taken to return a future that is immediately ready should be very small. It also remains the developer's responsibility to take care of the time taken for each command handler to be performed.

A consequence of the change is that all of the FSM types (state, command...) are required to implement Send.

Given the use of impl trait in return position, the MSRV is now 1.75.0. I've created a pre-1.75.0 branch for maintaining older code bases.