### PR TITLE
Introduces the Moore approach to state machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 
+resolver = "2"
+
 members = [
     "event-driven",
     "event-driven-macros"

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ impl Fsm for MyFsm {
 
     state!(Running / entry);
 
-    command_step!(Idle    => Start => Started => Running);
-    command_step!(Running => Stop  => Stopped => Idle);
+    command!(Idle    => Start => Started => Running);
+    command!(Running => Stop  => Stopped => Idle);
 
     ignore_command!(Idle    => Stop);
     ignore_command!(Running => Start);
@@ -64,7 +64,7 @@ fn on_entry_running(_old_s: &Running, _se: &mut EffectHandlers) {
 }
 ```
 
-The `command_step!` macro declares what should happen given a command using the form:
+The `command!` macro declares what should happen given a command using the form:
 
 ```
 <from-state> => <given-command> [=> <yields-event> [=> <to-state>]]
@@ -85,7 +85,7 @@ fn on_idle_started(_s: &Idle, _e: &Started) -> Option<Running> {
 }
 ```
 
-> Note that step declarations may also be provided for events using a `event_step!` macro (not shown). The form then becomes:
+> Note that inputs may also be provided as events using a `event!` macro (not shown). The form then becomes:
 > 
 > ```
 > <from-state> => <given-event> [=> <to-state>]
@@ -99,7 +99,7 @@ The `ignore_command!` macro describes those states and commands that should be i
 
 > Note if no `ignore_command!` declarations are provided then exhaustive matching on states and commands is not enforced.
 
-> There is a `ignore_event!` macro available for ignoring events where events are driving the steps.
+> There is a `ignore_event!` macro available for ignoring events where events are providing the input.
 
 State machines are then advanced given a mutable state and command. An optional event can be
 emitted along with a possible state transition e.g.:
@@ -126,13 +126,13 @@ a finer granularity of state with its fields, and so we wish to update them dire
 For example, given our previous representation of:
 
 ```rust
-command_step!(Running => Stop  => Stopped => Idle);
+command!(Running => Stop  => Stopped => Idle);
 ```
 
 ...if we change it to:
 
 ```rust
-command_step!(Running => Stop  => Stopped);
+command!(Running => Stop  => Stopped);
 ```
 
 i.e. if we remove the target state, then the associated function will be able to mutate the

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 edfsm - Event Driven Finite State Machine
 ===
 
-Event driven Finite State Machines process commands and events (possibly created by other
-events), possibly performing some side effect, and possibly emitting events.
+An Event Driven Finite State Machine is a useful formalism for control and monitoring applications.  The key concepts are:
 
-In one scenario, commands are processed against a provided state. Events can be applied to states
-to yield new states. This is known as a [Mealy](https://en.wikipedia.org/wiki/Mealy_machine) state machine. For more background: [Event-driven Finite State Machines](http://christopherhunt-software.blogspot.com/2021/02/event-driven-finite-state-machines.html).
+- The _state_ maintained by the state machine represents aspects of its external environment and its history.   
+- An _event_ represents a change in the environment and is one form of input to the state machine.  Reception of an event may cause the state to be updated.
+- A _command_ is an input to the state machine that may cause it to perform an effect.  An event may also be produced by the command which may update the state.
+- An _effect_ is some action that influences the environment.  
 
-In another scenario, events are applied to a provided state. This is known as a [Moore](https://en.wikipedia.org/wiki/Moore_machine)
-state machine.
+The effect, if any, produced by a command will depend on both the command and the a-priori state.  This models the _proactive_ behaviour of a [Mealy](https://en.wikipedia.org/wiki/Mealy_machine) machine.  An effect may also be produced after and event is processed and it will depend on the a-posteriori state.  This models the _reactive_ behaviour of a [Moore](https://en.wikipedia.org/wiki/Moore_machine) machine.
 
 Why edfsm?
 ---
@@ -64,7 +64,7 @@ The `command!` macro declares what should happen given a command using the form:
 <from-state> => <given-command> [=> <yields-event> [=> <to-state>]]
 ```
 
-> When declaring staets it is also possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
+> When declaring states it is also possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 
 In our example, for the first step declaration, multiple methods will be called that the developer must provide e.g.:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ let mut s = State::Idle(Idle);
 let c = Command::Start(Start);
 // Now step the state machine with the state and command,
 // and, an (undeclared) effect handler.
-let (e, t) = MyFsm::step(&mut s, Step::Command(c), &mut se);
+let (e, t) = MyFsm::step(&mut s, Input::Command(c), &mut se);
 ```
 
 State can also be re-constituted by replaying events. If there is no transition to an entirely

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ let mut s = State::Idle(Idle);
 let c = Command::Start(Start);
 // Now step the state machine with the state and command,
 // and, an (undeclared) effect handler.
-let (e, t) = MyFsm::step(&mut s, c, &mut se);
+let (e, t) = MyFsm::step(&mut s, Step::Command(c), &mut se);
 ```
 
 State can also be re-constituted by replaying events. If there is no transition to an entirely

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ to yield new states. This is known as a [Mealy](https://en.wikipedia.org/wiki/Me
 In another scenario, events are applied to a provided state. This is known as a [Moore](https://en.wikipedia.org/wiki/Moore_machine)
 state machine.
 
+Why use state machines in general?
+---
+
+State machines help you ask the question, what commands or events should I be able process for the current state I'm in...
+They help you model complexity.
+
+Why edfsm?
+---
+
+edfsm, and its DSL in particular, help you identify the functions required to handle commands and events given
+declared states, and strongly type their declarations. In short, edfsm is designed to enhance the code quality 
+of your state machine by leveraging the compiler to assert what your declaration of it.
+
 DSL
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 edfsm - Event Driven Finite State Machine
 ===
 
-Event driven Finite State Machines process commands (possibly created by other
+Event driven Finite State Machines process commands and events (possibly created by other
 events), possibly performing some side effect, and possibly emitting events.
 
-Commands are processed against a provided state. Events can be applied to states
-to yield new states.
+In one scenario, commands are processed against a provided state. Events can be applied to states
+to yield new states. This is known as a [Mealy](https://en.wikipedia.org/wiki/Mealy_machine) state machine. For more background: [Event-driven Finite State Machines](http://christopherhunt-software.blogspot.com/2021/02/event-driven-finite-state-machines.html).
 
-For more background: [Event-driven Finite State Machines](http://christopherhunt-software.blogspot.com/2021/02/event-driven-finite-state-machines.html).
+In another scenario, events are applied to a provided state. This is known as a [Moore](https://en.wikipedia.org/wiki/Moore_machine)
+state machine.
 
 DSL
 ---

--- a/event-driven-macros/src/expand.rs
+++ b/event-driven-macros/src/expand.rs
@@ -47,11 +47,11 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
         ));
     }
 
-    let mut command_matches = Vec::with_capacity(fsm.steps.len());
-    let mut event_matches = Vec::with_capacity(fsm.steps.len());
-    let mut change_matches = Vec::with_capacity(fsm.steps.len());
+    let mut command_matches = Vec::with_capacity(fsm.inputs.len());
+    let mut event_matches = Vec::with_capacity(fsm.inputs.len());
+    let mut change_matches = Vec::with_capacity(fsm.inputs.len());
 
-    for s in &fsm.steps {
+    for s in &fsm.inputs {
         let from_state = if let Type::Infer(_) = s.from_state() {
             None
         } else {

--- a/event-driven-macros/src/expand.rs
+++ b/event-driven-macros/src/expand.rs
@@ -149,7 +149,7 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
                         )),
                         Ordering::Greater => event_matches.push(quote!(
                             (#state_enum::#from_state(s), #event_enum::#event(e)) => {
-                                Some(Self::#event_handler(s, e))
+                                Self::#event_handler(s, e)
                             }
                         )),
                     }
@@ -171,7 +171,7 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
                     )),
                     Ordering::Greater => event_matches.push(quote!(
                         (s, #event_enum::#event(e)) => {
-                            Some(Self::#event_handler(s, e))
+                            Self::#event_handler(s, e)
                         }
                     )),
                 }

--- a/event-driven-macros/src/expand.rs
+++ b/event-driven-macros/src/expand.rs
@@ -49,11 +49,12 @@ pub fn expand(fsm: &mut Fsm) -> Result<TokenStream> {
         ));
     }
 
-    let mut command_matches = Vec::with_capacity(fsm.inputs.len());
-    let mut event_matches = Vec::with_capacity(fsm.inputs.len());
-    let mut change_matches = Vec::with_capacity(fsm.inputs.len());
+    let steps_len = fsm.steps.len();
+    let mut command_matches = Vec::with_capacity(steps_len);
+    let mut event_matches = Vec::with_capacity(steps_len);
+    let mut change_matches = Vec::with_capacity(steps_len);
 
-    for s in &fsm.inputs {
+    for s in &fsm.steps {
         let from_state = if let Type::Infer(_) = s.from_state() {
             None
         } else {

--- a/event-driven-macros/src/lib.rs
+++ b/event-driven-macros/src/lib.rs
@@ -15,28 +15,27 @@ use syn::parse2;
 /// #[impl_fsm]
 /// impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
 ///     state!(Running / entry);
-///     state!(Running / exit);
 ///
-///     transition!(Idle    => Start => Started => Running);
-///     transition!(Running => Stop  => Stopped => Idle);
+///     command_step!(Idle    => Start => Started => Running);
+///     command_step!(Running => Stop  => Stopped => Idle);
 ///
-///     ignore!(Idle    => Stop);
-///     ignore!(Running => Start);
+///     ignore_command!(Idle    => Stop);
+///     ignore_command!(Running => Start);
 /// }
 /// ```
 ///
 /// The `state!` macro declares state-related attributes. At this time, entry and exit
 /// handlers can be declared. In our example, the macro will ensure that an `on_entry_running`
-/// and an `on_exit_running` method will be called for `MyFsm`. The developer is then
+/// method will be called for `MyFsm`. The developer is then
 /// required to implement these methods e.g.:
 ///
 /// ```compile_fail
-/// fn on_exit_running(_old_s: &Running, _se: &mut EffectHandlers) {
+/// fn on_entry_running(_s: &Running, _se: &mut EffectHandlers) {
 ///     // Do something
 /// }
 /// ```
 ///
-/// The `transition!` macro declares an entire transition using the form:
+/// The `command_step!` macro declares an entire transition using the form:
 ///
 /// ```compile_fail
 /// <from-state> => <given-command> [=> <yields-event> []=> <to-state>]]
@@ -55,13 +54,15 @@ use syn::parse2;
 /// }
 /// ```
 ///
-/// The `ignore!` macro describes those states and commands that should be ignored given:
+/// The `ignore_command!` macro describes those states and commands that should be ignored given:
 ///
 /// ```compile_fail
 /// <from-state> => <given-command>
 /// ```
 ///
 /// It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
+///
+/// There are similar macros for events e.g. `event_step!` and `ignore_event`.
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn impl_fsm(input: TokenStream, annotated_item: TokenStream) -> TokenStream {

--- a/event-driven-macros/src/lib.rs
+++ b/event-driven-macros/src/lib.rs
@@ -24,10 +24,10 @@ use syn::parse2;
 /// }
 /// ```
 ///
-/// The `state!` macro declares state-related attributes. At this time, entry and exit
+/// The `state!` macro declares state-related attributes. At this time, only entry
 /// handlers can be declared. In our example, the macro will ensure that an `on_entry_running`
 /// method will be called for `MyFsm`. The developer is then
-/// required to implement these methods e.g.:
+/// required to implement a method e.g.:
 ///
 /// ```compile_fail
 /// fn on_entry_running(_s: &Running, _se: &mut EffectHandlers) {
@@ -62,7 +62,15 @@ use syn::parse2;
 ///
 /// It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 ///
-/// There are similar macros for events e.g. `event!` and `ignore_event`.
+/// There are similar macros for events e.g. `event!` and `ignore_event`. For `event!`, the declaration
+/// becomes:
+///
+/// ```compile_fail
+/// <from-state> => <given-event> [=> <to-state> [ / action]]
+/// ```
+///
+/// The `/ action` is optional and is used to declare that a side-effect is to be performed.
+
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn impl_fsm(input: TokenStream, annotated_item: TokenStream) -> TokenStream {

--- a/event-driven-macros/src/lib.rs
+++ b/event-driven-macros/src/lib.rs
@@ -16,8 +16,8 @@ use syn::parse2;
 /// impl Fsm<State, Command, Event, EffectHandlers> for MyFsm {
 ///     state!(Running / entry);
 ///
-///     command_step!(Idle    => Start => Started => Running);
-///     command_step!(Running => Stop  => Stopped => Idle);
+///     command!(Idle    => Start => Started => Running);
+///     command!(Running => Stop  => Stopped => Idle);
 ///
 ///     ignore_command!(Idle    => Stop);
 ///     ignore_command!(Running => Start);
@@ -35,7 +35,7 @@ use syn::parse2;
 /// }
 /// ```
 ///
-/// The `command_step!` macro declares an entire transition using the form:
+/// The `command!` macro declares an entire transition using the form:
 ///
 /// ```compile_fail
 /// <from-state> => <given-command> [=> <yields-event> []=> <to-state>]]
@@ -62,7 +62,7 @@ use syn::parse2;
 ///
 /// It is possible to use a wildcard i.e. `_` in place of `<from-state>` and `<to-state>`.
 ///
-/// There are similar macros for events e.g. `event_step!` and `ignore_event`.
+/// There are similar macros for events e.g. `event!` and `ignore_event`.
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn impl_fsm(input: TokenStream, annotated_item: TokenStream) -> TokenStream {

--- a/event-driven-macros/src/parse.rs
+++ b/event-driven-macros/src/parse.rs
@@ -3,7 +3,8 @@ use std::mem;
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
-    parse2, Error, Ident, ImplItem, ImplItemMacro, ImplItemType, ItemImpl, Result, Token, Type,
+    parse2, token, Error, Ident, ImplItem, ImplItemMacro, ImplItemType, ItemImpl, Result, Token,
+    Type,
 };
 
 #[derive(Debug, Eq, PartialEq)]
@@ -56,11 +57,11 @@ pub struct Transition {
 impl Parse for Transition {
     fn parse(input: ParseStream) -> Result<Self> {
         let from_state = input.parse()?;
-        input.parse::<Token![=>]>()?;
+        input.parse::<token::FatArrow>()?;
         let command = input.parse()?;
-        let (event, to_state) = if input.parse::<Token![=>]>().is_ok() {
+        let (event, to_state) = if input.parse::<token::FatArrow>().is_ok() {
             let event = Some(input.parse()?);
-            let to_state = if input.parse::<Token![=>]>().is_ok() {
+            let to_state = if input.parse::<token::FatArrow>().is_ok() {
                 Some(input.parse()?)
             } else {
                 None
@@ -87,7 +88,7 @@ pub struct Ignore {
 impl Parse for Ignore {
     fn parse(input: ParseStream) -> Result<Self> {
         let from_state = input.parse()?;
-        input.parse::<Token![=>]>()?;
+        input.parse::<token::FatArrow>()?;
         let command = input.parse()?;
         Ok(Self {
             from_state,

--- a/event-driven-macros/src/parse.rs
+++ b/event-driven-macros/src/parse.rs
@@ -194,7 +194,7 @@ pub struct Fsm {
     pub event_enum: Type,
     pub effect_handlers: Type,
     pub entry_handlers: Vec<Entry>,
-    pub inputs: Vec<Box<dyn Step>>,
+    pub steps: Vec<Box<dyn Step>>,
     pub ignore_commands: Vec<IgnoreCommand>,
     pub ignore_events: Vec<IgnoreEvent>,
     pub item_impl: ItemImpl,
@@ -211,7 +211,7 @@ impl Parse for Fsm {
         let mut event_enum = None;
         let mut effect_handlers = None;
         let mut entry_handlers = vec![];
-        let mut inputs = vec![];
+        let mut steps = vec![];
         let mut ignore_commands = vec![];
         let mut ignore_events = vec![];
 
@@ -245,11 +245,10 @@ impl Parse for Fsm {
                             entry_handlers.push(parse2(mac.tokens)?);
                         }
                         "command" => {
-                            inputs.push(Box::new(parse2::<CommandStep>(mac.tokens)?) as Box<dyn Step>);
+                            steps.push(Box::new(parse2::<CommandStep>(mac.tokens)?) as Box<dyn Step>);
                         }
                         "event" => {
-                            inputs
-                                .push(Box::new(parse2::<EventStep>(mac.tokens)?) as Box<dyn Step>);
+                            steps.push(Box::new(parse2::<EventStep>(mac.tokens)?) as Box<dyn Step>);
                         }
                         "ignore_command" => {
                             ignore_commands.push(parse2::<IgnoreCommand>(mac.tokens)?);
@@ -279,7 +278,7 @@ impl Parse for Fsm {
                 event_enum,
                 effect_handlers,
                 entry_handlers,
-                inputs,
+                steps,
                 ignore_commands,
                 ignore_events,
                 item_impl,

--- a/event-driven-macros/src/parse.rs
+++ b/event-driven-macros/src/parse.rs
@@ -213,6 +213,7 @@ mod tests {
                 transition!(Uninitialised  => GenerateRootKey => RootKeyGenerated => SsInitialised);
                 transition!(SsInitialised  => GenerateVpnKey  => VpnKeyGenerated  => VpnInitialised);
                 transition!(VpnInitialised => SetCredentials  => CredentialsSet   => Configurable);
+                transition!(VpnInitialised => _               => CredentialsSet   => Configurable);
                 transition!(_              => GetUsername);
                 transition!(_              => Reset           => FactoryReset     => Uninitialised);
                 transition!(_              => Reset           => SoftReset        => VpnInitialised);
@@ -245,6 +246,10 @@ mod tests {
                 .unwrap(),
                 parse2(
                     quote!(VpnInitialised => SetCredentials  => CredentialsSet   => Configurable)
+                )
+                .unwrap(),
+                parse2(
+                    quote!(VpnInitialised => _               => CredentialsSet   => Configurable)
                 )
                 .unwrap(),
                 parse2(quote!(_              => GetUsername)).unwrap(),

--- a/event-driven-macros/src/parse.rs
+++ b/event-driven-macros/src/parse.rs
@@ -194,7 +194,7 @@ pub struct Fsm {
     pub event_enum: Type,
     pub effect_handlers: Type,
     pub entry_handlers: Vec<Entry>,
-    pub steps: Vec<Box<dyn Step>>,
+    pub inputs: Vec<Box<dyn Step>>,
     pub ignore_commands: Vec<IgnoreCommand>,
     pub ignore_events: Vec<IgnoreEvent>,
     pub item_impl: ItemImpl,
@@ -211,7 +211,7 @@ impl Parse for Fsm {
         let mut event_enum = None;
         let mut effect_handlers = None;
         let mut entry_handlers = vec![];
-        let mut steps = vec![];
+        let mut inputs = vec![];
         let mut ignore_commands = vec![];
         let mut ignore_events = vec![];
 
@@ -244,11 +244,12 @@ impl Parse for Fsm {
                         "state" => {
                             entry_handlers.push(parse2(mac.tokens)?);
                         }
-                        "command_step" => {
-                            steps.push(Box::new(parse2::<CommandStep>(mac.tokens)?) as Box<dyn Step>);
+                        "command" => {
+                            inputs.push(Box::new(parse2::<CommandStep>(mac.tokens)?) as Box<dyn Step>);
                         }
-                        "event_step" => {
-                            steps.push(Box::new(parse2::<EventStep>(mac.tokens)?) as Box<dyn Step>);
+                        "event" => {
+                            inputs
+                                .push(Box::new(parse2::<EventStep>(mac.tokens)?) as Box<dyn Step>);
                         }
                         "ignore_command" => {
                             ignore_commands.push(parse2::<IgnoreCommand>(mac.tokens)?);
@@ -257,7 +258,7 @@ impl Parse for Fsm {
                             ignore_events.push(parse2::<IgnoreEvent>(mac.tokens)?);
                         }
                         n => {
-                            return Err(Error::new_spanned(mac, format!("Unknown macro: `{n}!`. Use only `state!`, `command_step!`, `event_step!`, `ignore_command!` and `ignore_event!` macros here.")));
+                            return Err(Error::new_spanned(mac, format!("Unknown macro: `{n}!`. Use only `state!`, `command!`, `event!`, `ignore_command!` and `ignore_event!` macros here.")));
                         }
                     }
                 }
@@ -278,7 +279,7 @@ impl Parse for Fsm {
                 event_enum,
                 effect_handlers,
                 entry_handlers,
-                steps,
+                inputs,
                 ignore_commands,
                 ignore_events,
                 item_impl,

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -1,10 +1,4 @@
-//! Event driven Finite State Machines process commands and events (possibly created by other
-//! events), performing some side effect, and emitting events.
-//! Commands are processed against a provided state. Events can be applied to states
-//! to yield new states.
-//!
-//! For more background on [Event-driven Finite State Machines](http://christopherhunt-software.blogspot.com/2021/02/event-driven-finite-state-machines.html).
-
+#![doc = include_str!("../../README.md")]
 #![no_std]
 
 pub use event_driven_macros::impl_fsm;
@@ -54,7 +48,7 @@ pub trait Fsm {
     /// Given a state and event, modify state, which could indicate transition to
     /// the next state. No side effects are to be performed. Can be used to replay
     /// events to attain a new state i.e. the major function of event sourcing.
-    /// Returns true if there is a state transition.
+    /// Returns some enumeration of the `Change` type if there is a state transition.
     fn on_event(s: &mut Self::S, e: &Self::E) -> Option<Change>;
 
     /// Given a state and event having been applied then handle any potential change
@@ -62,10 +56,11 @@ pub trait Fsm {
     /// This function is generally only called from the `step` function.
     fn on_change(s: &Self::S, e: &Self::E, se: &mut Self::SE, change: Change);
 
-    /// This is the main entry point to the event driven FSM.
+    /// This is the common entry point to the event driven FSM.
     /// Runs the state machine for a command input, optionally performing effects,
     /// possibly producing an event and possibly transitioning to a new state. Also
-    /// applies any "Entry/" processing when arriving at a new state.
+    /// applies any "Entry/" processing when arriving at a new state, and a change
+    /// handler if there is a state change.
     fn step(s: &mut Self::S, i: Input<Self::C, Self::E>, se: &mut Self::SE) -> Option<Self::E> {
         let e = match i {
             Input::Command(c) => Self::for_command(s, c, se),

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -10,7 +10,7 @@
 pub use event_driven_macros::impl_fsm;
 
 /// Type of step to perform - commands or events.
-pub enum Step<C, E> {
+pub enum Input<C, E> {
     Command(C),
     Event(E),
 }
@@ -66,10 +66,10 @@ pub trait Fsm {
     /// Runs the state machine for a command or event, optionally performing effects,
     /// possibly producing an event and possibly transitioning to a new state. Also
     /// applies any "Entry/" processing when arriving at a new state.
-    fn step(s: &mut Self::S, st: Step<Self::C, Self::E>, se: &mut Self::SE) -> Option<Self::E> {
+    fn step(s: &mut Self::S, st: Input<Self::C, Self::E>, se: &mut Self::SE) -> Option<Self::E> {
         let e = match st {
-            Step::Command(c) => Self::for_command(s, c, se),
-            Step::Event(e) => Some(e),
+            Input::Command(c) => Self::for_command(s, c, se),
+            Input::Event(e) => Some(e),
         };
         if let Some(e) = e {
             let r = Self::on_event(s, &e);
@@ -239,7 +239,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Idle(Idle),
-            Step::Command(Command::Start(Start)),
+            Input::Command(Command::Start(Start)),
             &mut se,
         );
         assert!(matches!(e, Some(Event::Started(Started))));
@@ -249,7 +249,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Running(Running),
-            Step::Command(Command::Start(Start)),
+            Input::Command(Command::Start(Start)),
             &mut se,
         );
         assert!(e.is_none());
@@ -259,7 +259,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Running(Running),
-            Step::Command(Command::Stop(Stop)),
+            Input::Command(Command::Stop(Stop)),
             &mut se,
         );
         assert!(matches!(e, Some(Event::Stopped(Stopped))));
@@ -269,7 +269,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Idle(Idle),
-            Step::Command(Command::Stop(Stop)),
+            Input::Command(Command::Stop(Stop)),
             &mut se,
         );
         assert!(e.is_none());
@@ -289,7 +289,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Idle(Idle),
-            Step::Event(Event::Started(Started)),
+            Input::Event(Event::Started(Started)),
             &mut se,
         );
         assert!(matches!(e, Some(Event::Started(Started))));
@@ -299,7 +299,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Running(Running),
-            Step::Event(Event::Started(Started)),
+            Input::Event(Event::Started(Started)),
             &mut se,
         );
         assert!(e.is_none());
@@ -309,7 +309,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Running(Running),
-            Step::Event(Event::Stopped(Stopped)),
+            Input::Event(Event::Stopped(Stopped)),
             &mut se,
         );
         assert!(matches!(e, Some(Event::Stopped(Stopped))));
@@ -319,7 +319,7 @@ mod tests {
 
         let e = MyFsm::step(
             &mut State::Idle(Idle),
-            Step::Event(Event::Stopped(Stopped)),
+            Input::Event(Event::Stopped(Stopped)),
             &mut se,
         );
         assert!(e.is_none());

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -9,12 +9,6 @@
 
 pub use event_driven_macros::impl_fsm;
 
-/// Type of step to perform - commands or events.
-pub enum Input<C, E> {
-    Command(C),
-    Event(E),
-}
-
 /// Describes a type of state change that `on_event` can perform.
 pub enum Change {
     Transitioned,
@@ -63,22 +57,27 @@ pub trait Fsm {
     fn on_change(s: &Self::S, e: &Self::E, se: &mut Self::SE, change: Change);
 
     /// This is the main entry point to the event driven FSM.
-    /// Runs the state machine for a command or event, optionally performing effects,
+    /// Runs the state machine for a command input, optionally performing effects,
     /// possibly producing an event and possibly transitioning to a new state. Also
     /// applies any "Entry/" processing when arriving at a new state.
-    fn step(s: &mut Self::S, i: Input<Self::C, Self::E>, se: &mut Self::SE) -> Option<Self::E> {
-        let e = match i {
-            Input::Command(c) => Self::for_command(s, c, se),
-            Input::Event(e) => Some(e),
-        };
+    fn step(s: &mut Self::S, c: Self::C, se: &mut Self::SE) -> Option<Self::E> {
+        let e = Self::for_command(s, c, se);
         if let Some(e) = e {
-            let r = Self::on_event(s, &e);
-            if let Some(c) = r {
-                Self::on_change(s, &e, se, c);
-                Some(e)
-            } else {
-                None
-            }
+            Self::step_event(s, e, se)
+        } else {
+            None
+        }
+    }
+
+    /// This is an alternate entry point to the event driven FSM.
+    /// Runs the state machine for a event input, optionally performing effects,
+    /// possibly producing an event and possibly transitioning to a new state. Also
+    /// applies any "Entry/" processing when arriving at a new state.
+    fn step_event(s: &mut Self::S, e: Self::E, se: &mut Self::SE) -> Option<Self::E> {
+        let r = Self::on_event(s, &e);
+        if let Some(c) = r {
+            Self::on_change(s, &e, se, c);
+            Some(e)
         } else {
             None
         }
@@ -237,41 +236,25 @@ mod tests {
 
         // First, test the FSM by stepping through various states given commands
 
-        let e = MyFsm::step(
-            &mut State::Idle(Idle),
-            Input::Command(Command::Start(Start)),
-            &mut se,
-        );
+        let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
         assert!(matches!(e, Some(Event::Started(Started))));
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(
-            &mut State::Running(Running),
-            Input::Command(Command::Start(Start)),
-            &mut se,
-        );
+        let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
         assert!(e.is_none());
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(
-            &mut State::Running(Running),
-            Input::Command(Command::Stop(Stop)),
-            &mut se,
-        );
+        let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
         assert!(matches!(e, Some(Event::Stopped(Stopped))));
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 1);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(
-            &mut State::Idle(Idle),
-            Input::Command(Command::Stop(Stop)),
-            &mut se,
-        );
+        let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
         assert!(e.is_none());
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 1);
@@ -287,19 +270,15 @@ mod tests {
 
         // Now, test the FSM by stepping through various states given events
 
-        let e = MyFsm::step(
-            &mut State::Idle(Idle),
-            Input::Event(Event::Started(Started)),
-            &mut se,
-        );
+        let e = MyFsm::step_event(&mut State::Idle(Idle), Event::Started(Started), &mut se);
         assert!(matches!(e, Some(Event::Started(Started))));
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(
+        let e = MyFsm::step_event(
             &mut State::Running(Running),
-            Input::Event(Event::Started(Started)),
+            Event::Started(Started),
             &mut se,
         );
         assert!(e.is_none());
@@ -307,9 +286,9 @@ mod tests {
         assert_eq!(se.stopped, 0);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(
+        let e = MyFsm::step_event(
             &mut State::Running(Running),
-            Input::Event(Event::Stopped(Stopped)),
+            Event::Stopped(Stopped),
             &mut se,
         );
         assert!(matches!(e, Some(Event::Stopped(Stopped))));
@@ -317,11 +296,7 @@ mod tests {
         assert_eq!(se.stopped, 1);
         assert_eq!(se.transitioned_stopped_to_started, 1);
 
-        let e = MyFsm::step(
-            &mut State::Idle(Idle),
-            Input::Event(Event::Stopped(Stopped)),
-            &mut se,
-        );
+        let e = MyFsm::step_event(&mut State::Idle(Idle), Event::Stopped(Stopped), &mut se);
         assert!(e.is_none());
         assert_eq!(se.started, 1);
         assert_eq!(se.stopped, 1);

--- a/event-driven/src/lib.rs
+++ b/event-driven/src/lib.rs
@@ -66,8 +66,8 @@ pub trait Fsm {
     /// Runs the state machine for a command or event, optionally performing effects,
     /// possibly producing an event and possibly transitioning to a new state. Also
     /// applies any "Entry/" processing when arriving at a new state.
-    fn step(s: &mut Self::S, st: Input<Self::C, Self::E>, se: &mut Self::SE) -> Option<Self::E> {
-        let e = match st {
+    fn step(s: &mut Self::S, i: Input<Self::C, Self::E>, se: &mut Self::SE) -> Option<Self::E> {
+        let e = match i {
             Input::Command(c) => Self::for_command(s, c, se),
             Input::Event(e) => Some(e),
         };

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -87,8 +87,8 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(O1)
     }
 
-    fn on_b_o1(_s: &B, _e: &O1) -> (Change, Option<State>) {
-        (Change::Updated, Some(State::A(A)))
+    fn on_b_o1(_s: &B, _e: &O1) -> Option<(Change, Option<State>)> {
+        Some((Change::Updated, Some(State::A(A))))
     }
 
     fn for_b_i2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use edfsm::{impl_fsm, Fsm, Step};
+use edfsm::{impl_fsm, Fsm, Input};
 
 struct A;
 struct B;
@@ -15,7 +15,7 @@ struct I0;
 struct I1;
 struct I2;
 struct I3;
-enum Input {
+enum Command {
     I0(I0),
     I1(I1),
     I2(I2),
@@ -25,7 +25,7 @@ enum Input {
 struct O0;
 struct O1;
 struct O2;
-enum Output {
+enum Event {
     O0(O0),
     O1(O1),
     O2(O2),
@@ -50,8 +50,8 @@ struct MyFsm<SE: EffectHandlers> {
 #[impl_fsm]
 impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
     type S = State;
-    type C = Input;
-    type E = Output;
+    type C = Command;
+    type E = Event;
     type SE = EffectHandlerBox<SE>;
 
     state!(B / entry);
@@ -128,8 +128,8 @@ fn main() {
     }
     let mut se = EffectHandlerBox(MyEffectHandlers);
 
-    let _ = MyFsm::step(&mut State::A(A), Step::Command(Input::I0(I0)), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Step::Command(Input::I1(I1)), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Step::Command(Input::I2(I2)), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Step::Command(Input::I3(I3)), &mut se);
+    let _ = MyFsm::step(&mut State::A(A), Input::Command(Command::I0(I0)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I1(I1)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I2(I2)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I3(I3)), &mut se);
 }

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use edfsm::{impl_fsm, Fsm};
+use edfsm::{impl_fsm, Change, Fsm};
 
 struct A;
 struct B;
@@ -87,8 +87,8 @@ impl<SE: EffectHandlers> MyFsm<SE> {
         Some(O1)
     }
 
-    fn on_b_o1(_s: &B, _e: &O1) -> Option<State> {
-        Some(State::A(A))
+    fn on_b_o1(_s: &B, _e: &O1) -> (Change, Option<State>) {
+        (Change::Updated, Some(State::A(A)))
     }
 
     fn for_b_i2(_s: &B, _c: I2, _se: &mut EffectHandlerBox<SE>) -> Option<O2> {

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use edfsm::{impl_fsm, Fsm, Input};
+use edfsm::{impl_fsm, Fsm};
 
 struct A;
 struct B;
@@ -128,8 +128,8 @@ fn main() {
     }
     let mut se = EffectHandlerBox(MyEffectHandlers);
 
-    let _ = MyFsm::step(&mut State::A(A), Input::Command(Command::I0(I0)), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I1(I1)), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I2(I2)), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I3(I3)), &mut se);
+    let _ = MyFsm::step(&mut State::A(A), Command::I0(I0), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Command::I1(I1), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Command::I2(I2), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Command::I3(I3), &mut se);
 }

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -56,15 +56,15 @@ impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
 
     state!(B / entry);
 
-    command_step!(A => I0 => O0 => B);
-    command_step!(B => I1 => O1 => A | B);
-    command_step!(B => I2 => O2);
-    event_step!(  B       => O2);
-    command_step!(B => I3);
+    command!(A => I0 => O0 => B);
+    command!(B => I1 => O1 => A | B);
+    command!(B => I2 => O2);
+    event!(  B       => O2);
+    command!(B => I3);
 
-    command_step!(_ => I1 => O1 => A);
-    command_step!(_ => I2 => O2);
-    command_step!(_ => I3);
+    command!(_ => I1 => O1 => A);
+    command!(_ => I2 => O2);
+    command!(_ => I3);
 
     ignore_event!(  A => O2);
     ignore_command!(B => I0);

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -59,7 +59,7 @@ impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
     command!(A => I0 => O0 => B);
     command!(B => I1 => O1 => A | B);
     command!(B => I2 => O2);
-    event!(  B       => O2);
+    event!(  B       => O2 / action);
     command!(B => I3);
 
     command!(_ => I1 => O1 => A);

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use edfsm::{impl_fsm, Fsm};
+use edfsm::{impl_fsm, Fsm, Step};
 
 struct A;
 struct B;
@@ -123,8 +123,8 @@ fn main() {
     }
     let mut se = EffectHandlerBox(MyEffectHandlers);
 
-    let _ = MyFsm::step(&mut State::A(A), Input::I0(I0), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::I1(I1), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::I2(I2), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Input::I3(I3), &mut se);
+    let _ = MyFsm::step(&mut State::A(A), Step::Command(Input::I0(I0)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Step::Command(Input::I1(I1)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Step::Command(Input::I2(I2)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Step::Command(Input::I3(I3)), &mut se);
 }

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-use edfsm::{impl_fsm, Change, Fsm};
+use edfsm::{impl_fsm, Change, Fsm, Input};
 
 struct A;
 struct B;
@@ -128,8 +128,8 @@ fn main() {
     }
     let mut se = EffectHandlerBox(MyEffectHandlers);
 
-    let _ = MyFsm::step(&mut State::A(A), Command::I0(I0), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Command::I1(I1), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Command::I2(I2), &mut se);
-    let _ = MyFsm::step(&mut State::B(B), Command::I3(I3), &mut se);
+    let _ = MyFsm::step(&mut State::A(A), Input::Command(Command::I0(I0)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I1(I1)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I2(I2)), &mut se);
+    let _ = MyFsm::step(&mut State::B(B), Input::Command(Command::I3(I3)), &mut se);
 }

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -59,7 +59,7 @@ impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
     transition!(A => I0 => O0 => B);
     transition!(B => I1 => O1 => A | B);
     transition!(B => I2 => O2);
-    transition!(B => _ => O2);
+    transition!(B => _  => O2);
     transition!(B => I3);
 
     transition!(_ => I1 => O1 => A);
@@ -94,6 +94,8 @@ impl<SE: EffectHandlers> MyFsm<SE> {
     }
 
     fn on_b_o2(_s: &B, _e: &O2) {}
+
+    fn on_change_b_o2(_s: &B, _e: &O2, _se: &mut EffectHandlerBox<SE>) {}
 
     fn for_b_i3(_s: &B, _c: I3, _se: &mut EffectHandlerBox<SE>) {}
 

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -59,6 +59,7 @@ impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
     transition!(A => I0 => O0 => B);
     transition!(B => I1 => O1 => A | B);
     transition!(B => I2 => O2);
+    transition!(B => _ => O2);
     transition!(B => I3);
 
     transition!(_ => I1 => O1 => A);

--- a/event-driven/tests/exercise_fsm.rs
+++ b/event-driven/tests/exercise_fsm.rs
@@ -56,17 +56,19 @@ impl<SE: EffectHandlers> Fsm for MyFsm<SE> {
 
     state!(B / entry);
 
-    transition!(A => I0 => O0 => B);
-    transition!(B => I1 => O1 => A | B);
-    transition!(B => I2 => O2);
-    transition!(B => _  => O2);
-    transition!(B => I3);
+    command_step!(A => I0 => O0 => B);
+    command_step!(B => I1 => O1 => A | B);
+    command_step!(B => I2 => O2);
+    event_step!(  B       => O2);
+    command_step!(B => I3);
 
-    transition!(_ => I1 => O1 => A);
-    transition!(_ => I2 => O2);
-    transition!(_ => I3);
+    command_step!(_ => I1 => O1 => A);
+    command_step!(_ => I2 => O2);
+    command_step!(_ => I3);
 
-    ignore!(B => I0);
+    ignore_event!(  A => O2);
+    ignore_command!(B => I0);
+    ignore_event!(  B => O0);
 }
 
 impl<SE: EffectHandlers> MyFsm<SE> {

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -1,6 +1,6 @@
 // Declare our state, commands and events
 
-use edfsm::{impl_fsm, Fsm, Input};
+use edfsm::{impl_fsm, Fsm};
 
 struct Idle;
 struct Running;
@@ -101,41 +101,25 @@ fn main() {
 
     // Finally, test the FSM by stepping through various states
 
-    let e = MyFsm::step(
-        &mut State::Idle(Idle),
-        Input::Command(Command::Start(Start)),
-        &mut se,
-    );
+    let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
     assert!(matches!(e, Some(Event::Started(Started))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(
-        &mut State::Running(Running),
-        Input::Command(Command::Start(Start)),
-        &mut se,
-    );
+    let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(
-        &mut State::Running(Running),
-        Input::Command(Command::Stop(Stop)),
-        &mut se,
-    );
+    let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
     assert!(matches!(e, Some(Event::Stopped(Stopped))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(
-        &mut State::Idle(Idle),
-        Input::Command(Command::Stop(Stop)),
-        &mut se,
-    );
+    let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -58,11 +58,11 @@ impl Fsm for MyFsm {
 
     state!(Running / entry);
 
-    transition!(Idle    => Start => Started => Running);
-    transition!(Running => Stop  => Stopped => Idle);
+    command_step!(Idle    => Start => Started => Running);
+    command_step!(Running => Stop  => Stopped => Idle);
 
-    ignore!(Idle    => Stop);
-    ignore!(Running => Start);
+    ignore_command!(Idle    => Stop);
+    ignore_command!(Running => Start);
 }
 
 impl MyFsm {

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -1,6 +1,6 @@
 // Declare our state, commands and events
 
-use edfsm::{impl_fsm, Fsm};
+use edfsm::{impl_fsm, Fsm, Step};
 
 struct Idle;
 struct Running;
@@ -101,25 +101,41 @@ fn main() {
 
     // Finally, test the FSM by stepping through various states
 
-    let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
+    let e = MyFsm::step(
+        &mut State::Idle(Idle),
+        Step::Command(Command::Start(Start)),
+        &mut se,
+    );
     assert!(matches!(e, Some(Event::Started(Started))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
+    let e = MyFsm::step(
+        &mut State::Running(Running),
+        Step::Command(Command::Start(Start)),
+        &mut se,
+    );
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(
+        &mut State::Running(Running),
+        Step::Command(Command::Stop(Stop)),
+        &mut se,
+    );
     assert!(matches!(e, Some(Event::Stopped(Stopped))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(
+        &mut State::Idle(Idle),
+        Step::Command(Command::Stop(Stop)),
+        &mut se,
+    );
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -1,6 +1,6 @@
 // Declare our state, commands and events
 
-use edfsm::{impl_fsm, Fsm, Step};
+use edfsm::{impl_fsm, Fsm, Input};
 
 struct Idle;
 struct Running;
@@ -103,7 +103,7 @@ fn main() {
 
     let e = MyFsm::step(
         &mut State::Idle(Idle),
-        Step::Command(Command::Start(Start)),
+        Input::Command(Command::Start(Start)),
         &mut se,
     );
     assert!(matches!(e, Some(Event::Started(Started))));
@@ -113,7 +113,7 @@ fn main() {
 
     let e = MyFsm::step(
         &mut State::Running(Running),
-        Step::Command(Command::Start(Start)),
+        Input::Command(Command::Start(Start)),
         &mut se,
     );
     assert!(e.is_none());
@@ -123,7 +123,7 @@ fn main() {
 
     let e = MyFsm::step(
         &mut State::Running(Running),
-        Step::Command(Command::Stop(Stop)),
+        Input::Command(Command::Stop(Stop)),
         &mut se,
     );
     assert!(matches!(e, Some(Event::Stopped(Stopped))));
@@ -133,7 +133,7 @@ fn main() {
 
     let e = MyFsm::step(
         &mut State::Idle(Idle),
-        Step::Command(Command::Stop(Stop)),
+        Input::Command(Command::Stop(Stop)),
         &mut se,
     );
     assert!(e.is_none());

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -1,6 +1,6 @@
 // Declare our state, commands and events
 
-use edfsm::{impl_fsm, Fsm};
+use edfsm::{impl_fsm, Fsm, Input};
 
 struct Idle;
 struct Running;
@@ -101,25 +101,41 @@ fn main() {
 
     // Finally, test the FSM by stepping through various states
 
-    let e = MyFsm::step(&mut State::Idle(Idle), Command::Start(Start), &mut se);
+    let e = MyFsm::step(
+        &mut State::Idle(Idle),
+        Input::Command(Command::Start(Start)),
+        &mut se,
+    );
     assert!(matches!(e, Some(Event::Started(Started))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Running(Running), Command::Start(Start), &mut se);
+    let e = MyFsm::step(
+        &mut State::Running(Running),
+        Input::Command(Command::Start(Start)),
+        &mut se,
+    );
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 0);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Running(Running), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(
+        &mut State::Running(Running),
+        Input::Command(Command::Stop(Stop)),
+        &mut se,
+    );
     assert!(matches!(e, Some(Event::Stopped(Stopped))));
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);
     assert_eq!(se.transitioned_stopped_to_started, 1);
 
-    let e = MyFsm::step(&mut State::Idle(Idle), Command::Stop(Stop), &mut se);
+    let e = MyFsm::step(
+        &mut State::Idle(Idle),
+        Input::Command(Command::Stop(Stop)),
+        &mut se,
+    );
     assert!(e.is_none());
     assert_eq!(se.started, 1);
     assert_eq!(se.stopped, 1);

--- a/event-driven/tests/simple_valid_imp_fsm.rs
+++ b/event-driven/tests/simple_valid_imp_fsm.rs
@@ -58,8 +58,8 @@ impl Fsm for MyFsm {
 
     state!(Running / entry);
 
-    command_step!(Idle    => Start => Started => Running);
-    command_step!(Running => Stop  => Stopped => Idle);
+    command!(Idle    => Start => Started => Running);
+    command!(Running => Stop  => Stopped => Idle);
 
     ignore_command!(Idle    => Stop);
     ignore_command!(Running => Start);


### PR DESCRIPTION
Supports Moore machines where an Event is the input, also introducing an `Input` type to discern between commands and events. Consequently, the `transition` macro has been renamed to convey inputs using either a new `command!` macro, or a new `event!` macro.

A new `on_change` handler is introduced so that changes to state caused by events can be handled with a side-effect. The type of change is passed to the handler and the `on_event` handler now declares the type of change. Previously, the `on_event` handler conveyed whether it was a transition or not. To get the `on_change` handler required from a macro perspective, a new `/ action` qualifier is required for the `event!` step declaration.