### PR TITLE
Terminating Machines

### DIFF
--- a/edfsm-kv-store/src/lib.rs
+++ b/edfsm-kv-store/src/lib.rs
@@ -193,6 +193,12 @@ where
     }
 }
 
+impl<A> Terminating for Keyed<A> {
+    fn terminating(&self) -> bool {
+        false
+    }
+}
+
 impl<S, SE> Init<S> for Keyed<SE> {
     fn init(&mut self, _state: &S) {}
 }

--- a/edfsm-machine/tests/fixtures/mod.rs
+++ b/edfsm-machine/tests/fixtures/mod.rs
@@ -14,6 +14,7 @@ pub enum Command {
 pub enum Event {
     Tick,
     Reset,
+    Stop,
 }
 
 #[derive(Clone, Debug)]
@@ -54,6 +55,7 @@ impl Fsm for Counter {
                     Some(Change::Updated)
                 }
             }
+            Event::Stop => Some(Change::Transitioned),
         }
     }
 
@@ -66,6 +68,6 @@ impl Fsm for Counter {
 
 impl Terminating for Event {
     fn terminating(&self) -> bool {
-        false
+        matches!(*self, Event::Stop)
     }
 }

--- a/edfsm-machine/tests/terminating.rs
+++ b/edfsm-machine/tests/terminating.rs
@@ -11,7 +11,7 @@ async fn producer(sender: Sender<Input<Command, Event>>) -> Result<()> {
     for _ in 1..50 {
         sender.send(Input::Event(Event::Tick)).await?;
     }
-    // sender.send(Input::Event(Event::Stop)).await?;
+    sender.send(Input::Event(Event::Stop)).await?;
     for _ in 50..100 {
         sender.send(Input::Event(Event::Tick)).await?;
     }

--- a/edfsm-machine/tests/terminating.rs
+++ b/edfsm-machine/tests/terminating.rs
@@ -1,0 +1,47 @@
+pub mod fixtures;
+use edfsm::Input;
+use edfsm_machine::{error::Result, machine, Machine};
+use fixtures::{Command, Counter, Event, Output};
+use tokio::{
+    sync::mpsc::{channel, Receiver, Sender},
+    task::JoinSet,
+};
+
+async fn producer(sender: Sender<Input<Command, Event>>) -> Result<()> {
+    for _ in 1..50 {
+        sender.send(Input::Event(Event::Tick)).await?;
+    }
+    // sender.send(Input::Event(Event::Stop)).await?;
+    for _ in 50..100 {
+        sender.send(Input::Event(Event::Tick)).await?;
+    }
+    Ok(())
+}
+
+async fn consumer(mut receiver: Receiver<Output>) -> Result<()> {
+    let mut count = 0;
+    while let Some(o) = receiver.recv().await {
+        println!("{o:?}");
+        count += 1;
+    }
+    println!("Count of tock: {count}");
+    assert_eq!(count, 4);
+    Ok(())
+}
+
+#[tokio::test]
+async fn terminating_test() {
+    let (send_o, recv_o) = channel::<Output>(3);
+    let log = Vec::<Event>::default();
+
+    let builder = machine::<Counter>().with_event_log(log).with_output(send_o);
+
+    let prod_task = producer(builder.input());
+    let cons_task = consumer(recv_o);
+
+    let mut set = JoinSet::new();
+    set.spawn(builder.task());
+    set.spawn(cons_task);
+    set.spawn(prod_task);
+    set.join_all().await;
+}

--- a/edfsm-macros/src/lib.rs
+++ b/edfsm-macros/src/lib.rs
@@ -70,7 +70,6 @@ use syn::parse2;
 /// ```
 ///
 /// The `/ action` is optional and is used to declare that a side-effect is to be performed.
-
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn impl_fsm(input: TokenStream, annotated_item: TokenStream) -> TokenStream {


### PR DESCRIPTION
Require Terminating trait in Machine events and break the main loop when such an event is received.