### PR TITLE
Disable edfsm-machine default dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ tokio = "1"
 
 edfsm = { path = "edfsm", version = "0.8.1" }
 edfsm-macros = { path = "edfsm-macros", version = "0.8.1" }
-edfsm-machine = { path = "edfsm-machine", default-features = false, version = "0.8.1" }
+edfsm-machine = { path = "edfsm-machine", version = "0.8.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,4 @@ tokio = "1"
 
 edfsm = { path = "edfsm", version = "0.8.1" }
 edfsm-macros = { path = "edfsm-macros", version = "0.8.1" }
-edfsm-kv-store = { path = "edfsm-kv-store", version = "0.8.1" }
-edfsm-machine = { path = "edfsm-machine", version = "0.8.1" }
+edfsm-machine = { path = "edfsm-machine", default-features = false, version = "0.8.1" }

--- a/edfsm-kv-store/Cargo.toml
+++ b/edfsm-kv-store/Cargo.toml
@@ -28,8 +28,6 @@ serde_json = { workspace = true }
 serde_qs = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
-edfsm-machine = { workspace = true }
-
 [features]
 default = ["tokio"]
 tokio = ["dep:tokio", "dep:edfsm-machine", "std"]

--- a/edfsm-kv-store/Cargo.toml
+++ b/edfsm-kv-store/Cargo.toml
@@ -24,6 +24,7 @@ edfsm = { workspace = true }
 edfsm-machine = { workspace = true, optional = true }
 
 [dev-dependencies]
+edfsm-machine = { workspace = true }	
 serde_json = { workspace = true }
 serde_qs = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/edfsm-machine/Cargo.toml
+++ b/edfsm-machine/Cargo.toml
@@ -19,7 +19,7 @@ edfsm.workspace = true
 
 [dev-dependencies]
 derive_more = { workspace = true, features = ["try_into"] }
-edfsm-machine = { path = ".", features = ["streambed"] }
+edfsm-machine = { workspace = true, features = ["streambed"] }
 serde = { workspace = true }
 streambed-logged = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/edfsm-machine/Cargo.toml
+++ b/edfsm-machine/Cargo.toml
@@ -19,12 +19,13 @@ edfsm.workspace = true
 
 [dev-dependencies]
 derive_more = { workspace = true, features = ["try_into"] }
+edfsm-machine = { path = ".", features = ["streambed"] }
 serde = { workspace = true }
 streambed-logged = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["tokio", "streambed"]
+default = ["tokio"]
 embassy = ["dep:embassy-sync"]
 std = []
 streambed = ["dep:streambed-codec"]


### PR DESCRIPTION
Defaults shouldn't be enabled for transitive lib dependencies. They can create additive issues downstream e.g. when using with WASM.