### PR TITLE
Introduce alloc

### DIFF
--- a/edfsm-kv-store/README.md
+++ b/edfsm-kv-store/README.md
@@ -3,3 +3,5 @@
 A [Key-Value Store](https://en.wikipedia.org/wiki/Key%E2%80%93value_database) based on edfsm's FSM trait implementation.
 The store is often wired up to use `edfsm-machine` and `streambed-logged` to use as a fully-fledged persistent database. All key/values
 are held in memory so only use for those scenarios where that is what is required.
+
+This library uses `core` and `alloc`.

--- a/edfsm-machine/Cargo.toml
+++ b/edfsm-machine/Cargo.toml
@@ -27,8 +27,9 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = ["tokio", "async-broadcast"]
+alloc = []
 embassy = ["dep:embassy-sync"]
-std = []
+std = ["alloc"]
 streambed = ["dep:streambed-codec"]
 tokio = ["dep:tokio", "std"]
 async-broadcast = ["dep:async-broadcast", "std"]

--- a/edfsm-machine/README.md
+++ b/edfsm-machine/README.md
@@ -12,3 +12,5 @@ by executors such as those provided by [tokio](https://github.com/tokio-rs/tokio
 
 Taking this further, a machine's inputs can be conveniently sourced from a [streambed-logged](https://github.com/streambed/streambed-rs/tree/main/streambed-logged)
 log of events that have been persisted, and logged back there. These adaptations provides an [event-sourcing](https://martinfowler.com/eaaDev/EventSourcing.html)-based Actor Model.
+
+This library assumes no_std and requires features such as `tokio` to make it useful.

--- a/edfsm-machine/src/lib.rs
+++ b/edfsm-machine/src/lib.rs
@@ -1,12 +1,14 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
+#[cfg(feature = "alloc")]
+extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
 pub mod adapter;
 pub mod error;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod output;
 
 #[cfg(feature = "tokio")]

--- a/edfsm-machine/src/output.rs
+++ b/edfsm-machine/src/output.rs
@@ -1,5 +1,5 @@
-use edfsm::{Drain, Init};
 use alloc::vec::Vec;
+use edfsm::{Drain, Init};
 
 #[derive(Debug)]
 pub struct OutputBuffer<A>(pub Vec<A>);

--- a/edfsm-machine/src/output.rs
+++ b/edfsm-machine/src/output.rs
@@ -1,5 +1,5 @@
 use edfsm::{Drain, Init};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 #[derive(Debug)]
 pub struct OutputBuffer<A>(pub Vec<A>);


### PR DESCRIPTION
Cleanup a use of Vec in the edfsm-machine output module - technically alloc, not std.